### PR TITLE
Allow more time for cal init

### DIFF
--- a/patches/israeli-bank-scrapers+3.7.0.patch
+++ b/patches/israeli-bank-scrapers+3.7.0.patch
@@ -20,3 +20,19 @@ index 4846f96..2b9c99c 100644
  export declare type ScraperTwoFactorAuthTriggerResult = ErrorResult | {
      success: true;
  };
+diff --git a/node_modules/israeli-bank-scrapers/lib/scrapers/visa-cal.js b/node_modules/israeli-bank-scrapers/lib/scrapers/visa-cal.js
+index c086464..3e921ed 100644
+--- a/node_modules/israeli-bank-scrapers/lib/scrapers/visa-cal.js
++++ b/node_modules/israeli-bank-scrapers/lib/scrapers/visa-cal.js
+@@ -253,7 +253,10 @@ class VisaCalScraper extends _baseScraperWithBrowser.BaseScraperWithBrowser {
+     const Authorization = await this.getAuthorizationHeader(); // Wait a little before `this.getCards` so that it would exist
+ 
+     await new Promise(resolve => setTimeout(resolve, 1000));
+-    const cards = await this.getCards();
++    const cards = await this.getCards().catch(async () => {
++      await new Promise(resolve => setTimeout(resolve, 5000));
++      return this.getCards();
++    });
+     const xSiteId = await this.getXSiteId();
+     const accounts = await Promise.all(cards.map(async card => {
+       var _this$options$outputD, _this$options$outputD2;


### PR DESCRIPTION
When scraping cal transactions, sometimes I get a "could not find 'init' data in session storage" error.
This patch allows a longer second attempt