### PR TITLE
Ignore "Bad Request: message is not modified"

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,8 +8,11 @@
       "type": "node",
       "request": "launch",
       "name": "Launch",
-      "runtimeArgs": [],
-      "args": ["${workspaceFolder}/dst/index.js"],
+      "program": "${workspaceFolder}/src/index.ts",
+      "outFiles": ["${workspaceFolder}/dst/**/*.js"],
+      "preLaunchTask": "tsc: build - tsconfig.json",
+      "skipFiles": ["<node_internals>/**"],
+      "outputCapture": "std",
       "env": {
         "DEBUG": "*"
       }

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -1,4 +1,4 @@
-import { Telegraf } from "telegraf";
+import { Telegraf, TelegramError } from "telegraf";
 import { Message } from "telegraf/typings/core/types/typegram";
 import {
   daysBackToScrape,
@@ -36,13 +36,28 @@ export async function editMessage(
   newText: string
 ) {
   if (message !== undefined) {
-    await bot?.telegram.editMessageText(
-      TELEGRAM_CHAT_ID,
-      message,
-      undefined,
-      newText
-    );
+    try {
+      await bot?.telegram.editMessageText(
+        TELEGRAM_CHAT_ID,
+        message,
+        undefined,
+        newText
+      );
+    } catch (e) {
+      if (canIgnoreTelegramError(e)) {
+        logger(`Ignoring error`, e);
+      } else {
+        throw e;
+      }
+    }
   }
+}
+
+function canIgnoreTelegramError(e: Error) {
+  return (
+    e instanceof TelegramError &&
+    e.response.description.startsWith("Bad Request: message is not modified")
+  );
 }
 
 export function sendError(message: any, caller: string = "") {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "sourceMap": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
     "esModuleInterop": true,


### PR DESCRIPTION
When editing a message without changing the text telegram throwes an error:
```
Error: 400: Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message
```

This error is not really an error, so no need to report it