### PR TITLE
[JSON Storage] Fix exported file name on windows

### DIFF
--- a/src/storage/json.ts
+++ b/src/storage/json.ts
@@ -27,7 +27,7 @@ export class LocalJsonStorage implements TransactionStorage {
 
     const fileName = path.join(
       LocalJsonStorage.folder,
-      `${new Date().toISOString()}.json`,
+      `${new Date().toISOString().replace(/:/g, "_")}.json`,
     );
 
     await fs.appendFile(fileName, JSON.stringify(txns), { encoding: "utf8" });


### PR DESCRIPTION
## What's the problem

When using `LocalJsonStorage` on windows the following error is thrown:
```
ENOENT: no such file or directory, open '<cwd>\output\2023-11-10T21:00:00.000Z.json'
```
This is caused by the `:` in the ISO string used as the file name.

## How it's fixed
Replacing `:` with `_` 


----
Fixes #182