### PR TITLE
Fix behatsdaa amount to be negative

### DIFF
--- a/patches/israeli-bank-scrapers+4.1.0+001+initial.patch
+++ b/patches/israeli-bank-scrapers+4.1.0+001+initial.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/israeli-bank-scrapers/lib/scrapers/behatsdaa.js b/node_modules/israeli-bank-scrapers/lib/scrapers/behatsdaa.js
+index a425681..479d207 100644
+--- a/node_modules/israeli-bank-scrapers/lib/scrapers/behatsdaa.js
++++ b/node_modules/israeli-bank-scrapers/lib/scrapers/behatsdaa.js
+@@ -29,14 +29,15 @@ const PURCHASE_HISTORY_URL = 'https://back.behatsdaa.org.il/api/purchases/purcha
+ const debug = (0, _debug.getDebug)('behatsdaa');
+ 
+ function variantToTransaction(variant) {
++  const amount = -variant.customerPrice;
+   return {
+     type: _transactions.TransactionTypes.Normal,
+     identifier: variant.tTransactionID,
+     date: (0, _moment.default)(variant.orderDate).format('YYYY-MM-DD'),
+     processedDate: (0, _moment.default)(variant.orderDate).format('YYYY-MM-DD'),
+-    originalAmount: variant.customerPrice,
++    originalAmount: amount,
+     originalCurrency: 'ILS',
+-    chargedAmount: variant.customerPrice,
++    chargedAmount: amount,
+     chargedCurrency: 'ILS',
+     description: variant.name,
+     status: _transactions.TransactionStatuses.Completed,


### PR DESCRIPTION
## Issue
The current implementation of the scraper takes the amount from the `customerPrice` field returned from the behatsdaa api result, which has the charged amount as a positive number.

## Changes
Patched to fix it until https://github.com/eshaham/israeli-bank-scrapers/pull/819 is merged