### PR TITLE
Fix: message has the whole installments amount and not charged amount

### DIFF
--- a/src/__snapshots__/messages.test.ts.snap
+++ b/src/__snapshots__/messages.test.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`messages getSummaryMessage should return a summary message 1`] = `
-"6 transactions scraped.
-(3 pending, 3 completed)
+"7 transactions scraped.
+(3 pending, 4 completed)
 
 Accounts updated:
-	✔️ [max] account1: 0
+	✔️ [max] account1: 1
 	✔️ [max] account2: 6
 
 Saved to:
@@ -38,6 +38,27 @@ Accounts updated:
 
 Saved to:
 	😶 None
+
+-------
+Pending txns:
+	😶 None"
+`;
+
+exports[`messages getSummaryMessage should return a summary message with installments 1`] = `
+"2 transactions scraped.
+(0 pending, 2 completed)
+
+Accounts updated:
+	✔️ [max] account1: 2
+
+Saved to:
+📝 Storage 1 (TheTable)
+	2 added
+	4 skipped (5 existing, 3 pending)
+	-----
+	SomeGroup:
+		should be +20:	+20.00
+		should be -20:	-20.00
 
 -------
 Pending txns:

--- a/src/messages.test.ts
+++ b/src/messages.test.ts
@@ -165,13 +165,13 @@ describe("messages", () => {
           type: TransactionTypes.Installments,
           chargedAmount: 20,
           originalAmount: 100,
-          description: "should be +20"
+          description: "should be +20",
         }),
         transaction({
           type: TransactionTypes.Installments,
           chargedAmount: -20,
           originalAmount: -100,
-          description: "should be -20"
+          description: "should be -20",
         }),
       ];
 
@@ -205,7 +205,6 @@ describe("messages", () => {
               companyId: CompanyTypes.max,
               hash: "hash1",
               ...t,
-            
             })),
           },
         },

--- a/src/messages.test.ts
+++ b/src/messages.test.ts
@@ -1,6 +1,11 @@
 import { CompanyTypes } from "israeli-bank-scrapers";
 import { getSummaryMessage } from "./messages";
-import { AccountScrapeResult, SaveStats, Transaction } from "./types";
+import {
+  AccountScrapeResult,
+  SaveStats,
+  Transaction,
+  TransactionRow,
+} from "./types";
 import {
   TransactionStatuses,
   TransactionTypes,
@@ -18,7 +23,15 @@ describe("messages", () => {
             accounts: [
               {
                 accountNumber: "account1",
-                txns: [],
+                txns: [
+                  transaction({
+                    chargedAmount: -20,
+                    originalAmount: -100,
+                    description: "ILS",
+                    chargedCurrency: "ILS",
+                    originalCurrency: "USD",
+                  }),
+                ],
               },
               {
                 accountNumber: "account2",
@@ -140,6 +153,63 @@ describe("messages", () => {
       ];
 
       const stats: Array<SaveStats> = [];
+
+      const summary = getSummaryMessage(results, stats);
+
+      expect(summary).toMatchSnapshot();
+    });
+
+    it("should return a summary message with installments", () => {
+      const transactions = [
+        transaction({
+          type: TransactionTypes.Installments,
+          chargedAmount: 20,
+          originalAmount: 100,
+          description: "should be +20"
+        }),
+        transaction({
+          type: TransactionTypes.Installments,
+          chargedAmount: -20,
+          originalAmount: -100,
+          description: "should be -20"
+        }),
+      ];
+
+      const results: Array<AccountScrapeResult> = [
+        {
+          companyId: CompanyTypes.max,
+          result: {
+            success: true,
+            accounts: [
+              {
+                accountNumber: "account1",
+                txns: transactions,
+              },
+            ],
+          },
+        },
+      ];
+
+      const stats: Array<SaveStats> = [
+        {
+          name: "Storage 1",
+          table: "TheTable",
+          total: 1,
+          added: 2,
+          pending: 3,
+          skipped: 4,
+          existing: 5,
+          highlightedTransactions: {
+            SomeGroup: transactions.map<TransactionRow>((t) => ({
+              account: "account1",
+              companyId: CompanyTypes.max,
+              hash: "hash1",
+              ...t,
+            
+            })),
+          },
+        },
+      ];
 
       const summary = getSummaryMessage(results, stats);
 


### PR DESCRIPTION
In the message sent, the originalAmount is sent instead of the chargedAmount.
This will hold the incorrect result in case of installments