### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Example:
 | `TZ`                    | `'Asia/Jerusalem'` | A timezone for the process - used for the formatting of the timestamp                                                                         |
 | `FUTURE_MONTHS`         | `1`                | The amount of months that will be scrapped in the future, starting from the day calculated using `DAYS_BACK`                                  |
 | `TRANSACTION_HASH_TYPE` | ``                 | The hash type to use for the transaction hash. Can be `moneyman` or empty. The default will be changed to `moneyman` in the upcoming versions |
+| `HIDDEN_DEPRECATIONS`   | ''                 | A comma separated list of deprecations to hide                                                                                                |
 
 ### Get notified in telegram
 

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -16,6 +16,13 @@ logToPublicLog(
 
 export async function send(message: string) {
   logger(message);
+  if (message.length > 4096) {
+    send(`Next message is too long (${message.length} characters), truncating`);
+    return await bot?.telegram.sendMessage(
+      TELEGRAM_CHAT_ID,
+      message.slice(0, 4096),
+    );
+  }
   return await bot?.telegram.sendMessage(TELEGRAM_CHAT_ID, message);
 }
 

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -65,7 +65,11 @@ export function sendError(message: any, caller: string = "") {
 const deprecationMessages = {
   ["hashFiledChange"]: `This run is using the old transaction hash field, please update to the new one (it might require manual de-duping of some transactions). See https://github.com/daniel-hauser/moneyman/issues/268 for more details.`,
 } as const;
-const sentDeprecationMessages = new Set<string>();
+const { HIDDEN_DEPRECATIONS = "" } = process.env;
+logger(`Hidden deprecations: ${HIDDEN_DEPRECATIONS}`);
+
+const sentDeprecationMessages = new Set<string>(HIDDEN_DEPRECATIONS.split(","));
+
 export function sendDeprecationMessage(
   messageId: keyof typeof deprecationMessages,
 ) {


### PR DESCRIPTION
* [`src/notifier.ts`](diffhunk://#diff-5f8382d927f65fd353aa13dd3f49dcdd7c6c51515ab46eb03fccd081a45997f7R19-R25): In the `send` function, a check has been added to ensure that the message length does not exceed 4096 characters. If it does, the message is truncated and a notification about the truncation is sent.
This is to prevent https://github.com/telegraf/telegraf/discussions/1785
* [`src/notifier.ts`](diffhunk://#diff-5f8382d927f65fd353aa13dd3f49dcdd7c6c51515ab46eb03fccd081a45997f7L68-R79): In the `sendDeprecationMessage` function, the `HIDDEN_DEPRECATIONS` environment variable is now used to initialize the `sentDeprecationMessages` set, effectively hiding the specified deprecation messages. Also, a log message has been added to log the hidden deprecations.