### PR TITLE
Split status messages

### DIFF
--- a/src/__snapshots__/messages.test.ts.snap
+++ b/src/__snapshots__/messages.test.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`messages getSummaryMessage should return a summary message 1`] = `
-"7 transactions scraped.
+exports[`messages getSummaryMessages should return a summary message 1`] = `
+[
+  "7 transactions scraped.
 (3 pending, 4 completed)
 
 Accounts updated:
 	✔️ [max] account1: 1
-	✔️ [max] account2: 6
-
-Saved to:
+	✔️ [max] account2: 6",
+  "Saved to:
 📝 Storage 1 (TheTable)
 	2 added
 	4 skipped (5 existing, 3 pending)
@@ -23,35 +23,37 @@ Saved to:
 Pending txns:
 	description1:	+20.00
 	description1:	+20.00 USD
-	description1:	-20.00"
+	description1:	-20.00",
+]
 `;
 
-exports[`messages getSummaryMessage should return a summary message with failed results 1`] = `
-"1 transactions scraped.
+exports[`messages getSummaryMessages should return a summary message with failed results 1`] = `
+[
+  "1 transactions scraped.
 (0 pending, 1 completed)
 
 Accounts updated:
 	❌ [max] GENERIC
 		Some error message
 	❌ [hapoalim] CHANGE_PASSWORD
-	✔️ [hapoalim] account1: 1
-
-Saved to:
+	✔️ [hapoalim] account1: 1",
+  "Saved to:
 	😶 None
 
 -------
 Pending txns:
-	😶 None"
+	😶 None",
+]
 `;
 
-exports[`messages getSummaryMessage should return a summary message with installments 1`] = `
-"2 transactions scraped.
+exports[`messages getSummaryMessages should return a summary message with installments 1`] = `
+[
+  "2 transactions scraped.
 (0 pending, 2 completed)
 
 Accounts updated:
-	✔️ [max] account1: 2
-
-Saved to:
+	✔️ [max] account1: 2",
+  "Saved to:
 📝 Storage 1 (TheTable)
 	2 added
 	4 skipped (5 existing, 3 pending)
@@ -62,19 +64,21 @@ Saved to:
 
 -------
 Pending txns:
-	😶 None"
+	😶 None",
+]
 `;
 
-exports[`messages getSummaryMessage should return a summary message with no results 1`] = `
-"0 transactions scraped.
+exports[`messages getSummaryMessages should return a summary message with no results 1`] = `
+[
+  "0 transactions scraped.
 
 Accounts updated:
-	😶 None
-
-Saved to:
+	😶 None",
+  "Saved to:
 	😶 None
 
 -------
 Pending txns:
-	😶 None"
+	😶 None",
+]
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { accounts, futureMonthsToScrape, scrapeStartDate } from "./config.js";
 import { send, editMessage, sendError } from "./notifier.js";
 import { initializeStorage, saveResults, storages } from "./storage/index.js";
 import { createLogger, logToPublicLog } from "./utils/logger.js";
-import { getSummaryMessage, getSummaryMessages } from "./messages.js";
+import { getSummaryMessages } from "./messages.js";
 
 const logger = createLogger("main");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { accounts, futureMonthsToScrape, scrapeStartDate } from "./config.js";
 import { send, editMessage, sendError } from "./notifier.js";
 import { initializeStorage, saveResults, storages } from "./storage/index.js";
 import { createLogger, logToPublicLog } from "./utils/logger.js";
-import { getSummaryMessage } from "./messages.js";
+import { getSummaryMessage, getSummaryMessages } from "./messages.js";
 
 const logger = createLogger("main");
 
@@ -49,9 +49,9 @@ async function run() {
       ]);
 
       const saved = await saveResults(results);
-      const summary = getSummaryMessage(results, saved.stats);
-
-      await send(summary);
+      for (const message of getSummaryMessages(results, saved.stats)) {
+        await send(message);
+      }
     } catch (e) {
       logger(e);
       await sendError(e);

--- a/src/messages.test.ts
+++ b/src/messages.test.ts
@@ -1,5 +1,5 @@
 import { CompanyTypes } from "israeli-bank-scrapers";
-import { getSummaryMessage } from "./messages";
+import { getSummaryMessages } from "./messages";
 import {
   AccountScrapeResult,
   SaveStats,
@@ -13,7 +13,7 @@ import {
 import { ScraperErrorTypes } from "israeli-bank-scrapers/lib/scrapers/errors";
 
 describe("messages", () => {
-  describe("getSummaryMessage", () => {
+  describe("getSummaryMessages", () => {
     it("should return a summary message", () => {
       const results: Array<AccountScrapeResult> = [
         {
@@ -107,7 +107,7 @@ describe("messages", () => {
         },
       ];
 
-      const summary = getSummaryMessage(results, stats);
+      const summary = getSummaryMessages(results, stats);
 
       expect(summary).toMatchSnapshot();
     });
@@ -117,7 +117,7 @@ describe("messages", () => {
 
       const stats: Array<SaveStats> = [];
 
-      const summary = getSummaryMessage(results, stats);
+      const summary = getSummaryMessages(results, stats);
 
       expect(summary).toMatchSnapshot();
     });
@@ -155,7 +155,7 @@ describe("messages", () => {
 
       const stats: Array<SaveStats> = [];
 
-      const summary = getSummaryMessage(results, stats);
+      const summary = getSummaryMessages(results, stats);
 
       expect(summary).toMatchSnapshot();
     });
@@ -212,7 +212,7 @@ describe("messages", () => {
         },
       ];
 
-      const summary = getSummaryMessage(results, stats);
+      const summary = getSummaryMessages(results, stats);
 
       expect(summary).toMatchSnapshot();
     });

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -9,7 +9,7 @@ import {
   TransactionRow,
 } from "./types";
 
-export function getSummaryMessage(
+export function getSummaryMessages(
   results: Array<AccountScrapeResult>,
   stats: Array<SaveStats>,
 ) {
@@ -27,19 +27,21 @@ export function getSummaryMessage(
 
   const { pending, completed } = transactionsByStatus(results);
 
-  return `
+  return [
+    `
 ${transactionsString(pending, completed)}
 
 Accounts updated:
-${accountsSummary.join("\n") || "\t😶 None"}
-
+${accountsSummary.join("\n") || "\t😶 None"}`.trim(),
+    `
 Saved to:
 ${stats.map((s) => statsString(s)).join("\n") || "\t😶 None"}
 
 -------
 Pending txns:
 ${transactionList(pending) || "\t😶 None"}
-`.trim();
+`.trim(),
+  ];
 }
 
 function transactionsString(


### PR DESCRIPTION
In some cases, the status message s too long, resulting with an error/truncation when sending.
This change will split the message, resulting with a lower chance of errors