### PR TITLE
Update dependancies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,12 @@
         "azure-kusto-ingest": "^6.0.2",
         "buxfer-ts-client": "^1.0.4",
         "date-fns": "^3.6.0",
-        "debug": "^4.3.4",
+        "debug": "^4.3.5",
         "dotenv": "^16.4.5",
-        "google-auth-library": "^9.9.0",
-        "google-spreadsheet": "^4.1.1",
+        "google-auth-library": "^9.11.0",
+        "google-spreadsheet": "^4.1.2",
         "hash-it": "^6.0.0",
-        "israeli-bank-scrapers": "^4.5.0",
+        "israeli-bank-scrapers": "^4.5.4",
         "telegraf": "^4.16.3",
         "ynab": "^2.2.0"
       },
@@ -29,10 +29,10 @@
         "husky": "^9.0.11",
         "jest": "^29.7.0",
         "patch-package": "^8.0.0",
-        "prettier": "^3.2.5",
+        "prettier": "^3.3.2",
         "pretty-quick": "^4.0.0",
-        "ts-jest": "^29.1.2",
-        "typescript": "^5.4.5"
+        "ts-jest": "^29.1.5",
+        "typescript": "^5.5.2"
       },
       "engines": {
         "node": ">16"
@@ -2372,9 +2372,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2940,9 +2940,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.9.0.tgz",
-      "integrity": "sha512-9l+zO07h1tDJdIHN74SpnWIlNR+OuOemXlWJlLP9pXy6vFtizgpEzMuwJa4lqY9UAdiAv5DVd5ql0Am916I+aA==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.11.0.tgz",
+      "integrity": "sha512-epX3ww/mNnhl6tL45EQ/oixsY8JLEgUFoT4A5E/5iAR4esld9Kqv6IJGk7EmGuOgDvaarwF95hU2+v7Irql9lw==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -2956,9 +2956,9 @@
       }
     },
     "node_modules/google-spreadsheet": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/google-spreadsheet/-/google-spreadsheet-4.1.1.tgz",
-      "integrity": "sha512-Npk/xAMTgxEt/m/X9EXIqdY6CEYGiqUHrSuiLnNSKli5H+wiOQLSLsnfMxcdNPH6aSh6GttZm6QJhrnsxjwpZQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/google-spreadsheet/-/google-spreadsheet-4.1.2.tgz",
+      "integrity": "sha512-HFBweDAkOcyC2qO9kmWESKbNuOcn+R7UzZN/tj5LLNxVv8FHmg113u0Ow+yaKwwIOt/NnDtPLuptAhaxTs0FYw==",
       "dependencies": {
         "axios": "^1.4.0",
         "lodash": "^4.17.21"
@@ -3280,9 +3280,9 @@
       "dev": true
     },
     "node_modules/israeli-bank-scrapers": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/israeli-bank-scrapers/-/israeli-bank-scrapers-4.5.0.tgz",
-      "integrity": "sha512-EqVancG7OKOTqDC0oxVzqLV4HFlzj/GlghfmSfy4hJGV6i1yb9tvJmjtBWBVtXBkEX0btkUyezs+boxGycGtjQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/israeli-bank-scrapers/-/israeli-bank-scrapers-4.5.4.tgz",
+      "integrity": "sha512-2lIpbMM+bgKnH/Qj/sNXef8PD5UB5GgyZzA0s8fj3OF5a0oQWyyxZuSbxjFSly2//4ufV1QJmYTz7OatBeNBIw==",
       "dependencies": {
         "build-url": "^2.0.0",
         "core-js": "^3.1.4",
@@ -4773,9 +4773,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -5582,9 +5582,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-jest": {
-      "version": "29.1.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
-      "integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
+      "version": "29.1.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.5.tgz",
+      "integrity": "sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
@@ -5600,10 +5600,11 @@
         "ts-jest": "cli.js"
       },
       "engines": {
-        "node": "^16.10.0 || ^18.0.0 || >=20.0.0"
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0",
         "@jest/types": "^29.0.0",
         "babel-jest": "^29.0.0",
         "jest": "^29.0.0",
@@ -5611,6 +5612,9 @@
       },
       "peerDependenciesMeta": {
         "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
           "optional": true
         },
         "@jest/types": {
@@ -5674,9 +5678,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7831,9 +7835,9 @@
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -8225,9 +8229,9 @@
       "dev": true
     },
     "google-auth-library": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.9.0.tgz",
-      "integrity": "sha512-9l+zO07h1tDJdIHN74SpnWIlNR+OuOemXlWJlLP9pXy6vFtizgpEzMuwJa4lqY9UAdiAv5DVd5ql0Am916I+aA==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.11.0.tgz",
+      "integrity": "sha512-epX3ww/mNnhl6tL45EQ/oixsY8JLEgUFoT4A5E/5iAR4esld9Kqv6IJGk7EmGuOgDvaarwF95hU2+v7Irql9lw==",
       "requires": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -8238,9 +8242,9 @@
       }
     },
     "google-spreadsheet": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/google-spreadsheet/-/google-spreadsheet-4.1.1.tgz",
-      "integrity": "sha512-Npk/xAMTgxEt/m/X9EXIqdY6CEYGiqUHrSuiLnNSKli5H+wiOQLSLsnfMxcdNPH6aSh6GttZm6QJhrnsxjwpZQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/google-spreadsheet/-/google-spreadsheet-4.1.2.tgz",
+      "integrity": "sha512-HFBweDAkOcyC2qO9kmWESKbNuOcn+R7UzZN/tj5LLNxVv8FHmg113u0Ow+yaKwwIOt/NnDtPLuptAhaxTs0FYw==",
       "requires": {
         "axios": "^1.4.0",
         "lodash": "^4.17.21"
@@ -8460,9 +8464,9 @@
       "dev": true
     },
     "israeli-bank-scrapers": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/israeli-bank-scrapers/-/israeli-bank-scrapers-4.5.0.tgz",
-      "integrity": "sha512-EqVancG7OKOTqDC0oxVzqLV4HFlzj/GlghfmSfy4hJGV6i1yb9tvJmjtBWBVtXBkEX0btkUyezs+boxGycGtjQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/israeli-bank-scrapers/-/israeli-bank-scrapers-4.5.4.tgz",
+      "integrity": "sha512-2lIpbMM+bgKnH/Qj/sNXef8PD5UB5GgyZzA0s8fj3OF5a0oQWyyxZuSbxjFSly2//4ufV1QJmYTz7OatBeNBIw==",
       "requires": {
         "build-url": "^2.0.0",
         "core-js": "^3.1.4",
@@ -9587,9 +9591,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true
     },
     "pretty-format": {
@@ -10196,9 +10200,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "ts-jest": {
-      "version": "29.1.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
-      "integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
+      "version": "29.1.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.5.tgz",
+      "integrity": "sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -10245,9 +10249,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true
     },
     "unbzip2-stream": {

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "azure-kusto-ingest": "^6.0.2",
     "buxfer-ts-client": "^1.0.4",
     "date-fns": "^3.6.0",
-    "debug": "^4.3.4",
+    "debug": "^4.3.5",
     "dotenv": "^16.4.5",
-    "google-auth-library": "^9.9.0",
-    "google-spreadsheet": "^4.1.1",
+    "google-auth-library": "^9.11.0",
+    "google-spreadsheet": "^4.1.2",
     "hash-it": "^6.0.0",
-    "israeli-bank-scrapers": "^4.5.0",
+    "israeli-bank-scrapers": "^4.5.4",
     "telegraf": "^4.16.3",
     "ynab": "^2.2.0"
   },
@@ -46,10 +46,10 @@
     "husky": "^9.0.11",
     "jest": "^29.7.0",
     "patch-package": "^8.0.0",
-    "prettier": "^3.2.5",
+    "prettier": "^3.3.2",
     "pretty-quick": "^4.0.0",
-    "ts-jest": "^29.1.2",
-    "typescript": "^5.4.5"
+    "ts-jest": "^29.1.5",
+    "typescript": "^5.5.2"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This pull request primarily includes updates to the version numbers of several dependencies in the `package.json` file. These updates ensure that the project uses the latest stable versions of these dependencies, which can include new features, bug fixes, and security patches.

Here are the most important changes:

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R39): Updated the version of `debug` from `^4.3.4` to `^4.3.5`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R39): Updated the versions of `google-auth-library` and `google-spreadsheet` from `^9.9.0` and `^4.1.1` to `^9.11.0` and `^4.1.2` respectively.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R39): Updated the version of `israeli-bank-scrapers` from `^4.5.0` to `^4.5.4`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R52): Updated the version of `prettier` from `^3.2.5` to `^3.3.2`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R52): Updated the versions of `ts-jest` and `typescript` from `^29.1.2` and `^5.4.5` to `^29.1.5` and `^5.5.2` respectively.
*

Fixes #287 