### PR TITLE
increase the telegram timeout number

### DIFF
--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -41,7 +41,7 @@ export async function editMessage(
        * To avoid getting 429 errors, we wait a bit before sending the edit request.
        * According to the docs, the limit is 30 messages per second so we should be safe with 250ms.
        */
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      await new Promise((resolve) => setTimeout(resolve, 500));
       await bot?.telegram.editMessageText(
         TELEGRAM_CHAT_ID,
         message,


### PR DESCRIPTION
Hi @daniel-hauser 
I still experience issues with Telegram, and all the scrape processes are terminated. I received a general error in my action log:
https://github.com/roisec/moneyman/actions/runs/9889038748/job/27314228767#step:4:43

The issues occur only on GitHub Actions and not locally. Do you have an idea of how to solve this? Telegram maybe rate limit GitHub IPs more aggressively?

e.g
I added 2 2-second delay and still getting errors to GitHub actions and received 429.
