### PR TITLE
fix(isracard): PATCH use the correct value for originalCurrency

### DIFF
--- a/patches/israeli-bank-scrapers+5.1.1.patch
+++ b/patches/israeli-bank-scrapers+5.1.1.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/israeli-bank-scrapers/lib/scrapers/base-isracard-amex.js b/node_modules/israeli-bank-scrapers/lib/scrapers/base-isracard-amex.js
+index e798027..7af1e12 100644
+--- a/node_modules/israeli-bank-scrapers/lib/scrapers/base-isracard-amex.js
++++ b/node_modules/israeli-bank-scrapers/lib/scrapers/base-isracard-amex.js
+@@ -110,8 +110,9 @@ function convertTransactions(txns, processedDate) {
+       date: txnMoment.toISOString(),
+       processedDate: currentProcessedDate,
+       originalAmount: isOutbound ? -txn.dealSumOutbound : -txn.dealSum,
+-      originalCurrency: convertCurrency(txn.currencyId),
++      originalCurrency: convertCurrency(txn.currentPaymentCurrency),
+       chargedAmount: isOutbound ? -txn.paymentSumOutbound : -txn.paymentSum,
++      chargedCurrency: convertCurrency(txn.currencyId),
+       description: isOutbound ? txn.fullSupplierNameOutbound : txn.fullSupplierNameHeb,
+       memo: txn.moreInfo || '',
+       installments: getInstallmentsInfo(txn) || undefined,


### PR DESCRIPTION
Transactions in isracard has the wrong originalCurrency. the correct mapping of the currencies should be:
- `originalCurrency` = `currentPaymentCurrency`
- `chargedCurrency` = `currencyId`

This PR patches until https://github.com/eshaham/israeli-bank-scrapers/pull/871 is merged