### PR TITLE
chore: Update Node.js version requirement to >=20

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, latest]
+        node-version: [20, latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "typescript": "^5.5.4"
       },
       "engines": {
-        "node": ">16"
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dst/index.ts",
   "type": "module",
   "engines": {
-    "node": ">16"
+    "node": ">=20"
   },
   "scripts": {
     "act": "go run github.com/nektos/act@latest",


### PR DESCRIPTION
This pull request updates the Node.js version used in the project configuration files to ensure compatibility with newer Node.js versions. The most important changes include updating the Node.js version in the GitHub Actions workflow and the `package.json` file.

### Node.js Version Updates:

* [`.github/workflows/verify-build.yml`](diffhunk://#diff-936fbed6fe307d4f159b5e5b3901d9d4ba5f7ca810a6d185e8c965ad26adf9f0L15-R15): Updated the Node.js version in the matrix strategy from `16.x` to `20` and `latest`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8-R8): Changed the required Node.js version in the `engines` field from `>16` to `>=20`.