### PR TITLE
fix: runtime import error import error

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,7 @@ export default {
   preset: "ts-jest",
   testEnvironment: "node",
   rootDir: "./src",
+  moduleNameMapper: {
+    "^(\\.\\.?\\/.+)\\.jsx?$": "$1",
+  },
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { subDays, format } from "date-fns";
-import { AccountConfig } from "./types";
+import { AccountConfig } from "./types.js";
 import { createLogger, logToPublicLog } from "./utils/logger.js";
 
 const logger = createLogger("config");

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,6 +1,6 @@
 import { performance } from "perf_hooks";
 import { getAccountTransactions } from "./scrape.js";
-import { AccountConfig, AccountScrapeResult } from "../types";
+import { AccountConfig, AccountScrapeResult } from "../types.js";
 import { createLogger } from "../utils/logger.js";
 
 const logger = createLogger("data");

--- a/src/messages.test.ts
+++ b/src/messages.test.ts
@@ -1,12 +1,12 @@
 import { CompanyTypes } from "israeli-bank-scrapers";
-import { getSummaryMessages } from "./messages";
-import { AccountScrapeResult, Transaction, TransactionRow } from "./types";
+import { getSummaryMessages } from "./messages.js";
+import { AccountScrapeResult, Transaction, TransactionRow } from "./types.js";
 import {
   TransactionStatuses,
   TransactionTypes,
-} from "israeli-bank-scrapers/lib/transactions";
-import { ScraperErrorTypes } from "israeli-bank-scrapers/lib/scrapers/errors";
-import { createSaveStats, SaveStats, statsString } from "./saveStats";
+} from "israeli-bank-scrapers/lib/transactions.js";
+import { ScraperErrorTypes } from "israeli-bank-scrapers/lib/scrapers/errors.js";
+import { createSaveStats, SaveStats, statsString } from "./saveStats.js";
 
 describe("messages", () => {
   describe("getSummaryMessages", () => {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -3,7 +3,7 @@ import {
   TransactionTypes,
 } from "israeli-bank-scrapers/lib/transactions.js";
 import { AccountScrapeResult, Transaction } from "./types";
-import { normalizeCurrency } from "./utils/currency";
+import { normalizeCurrency } from "./utils/currency.js";
 
 export function getSummaryMessages(results: Array<AccountScrapeResult>) {
   const accountsSummary = results.flatMap(({ result, companyId }) => {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -2,7 +2,7 @@ import {
   TransactionStatuses,
   TransactionTypes,
 } from "israeli-bank-scrapers/lib/transactions.js";
-import { AccountScrapeResult, Transaction } from "./types";
+import { AccountScrapeResult, Transaction } from "./types.js";
 import { normalizeCurrency } from "./utils/currency.js";
 
 export function getSummaryMessages(results: Array<AccountScrapeResult>) {

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -1,5 +1,4 @@
 import { Telegraf, TelegramError } from "telegraf";
-import { Message } from "telegraf/typings/core/types/typegram";
 import { TELEGRAM_API_KEY, TELEGRAM_CHAT_ID } from "./config.js";
 import { createLogger, logToPublicLog } from "./utils/logger.js";
 
@@ -30,10 +29,6 @@ export async function sendPhoto(photoPath: string, caption: string) {
     { source: photoPath },
     { caption, has_spoiler: true },
   );
-}
-
-export async function deleteMessage(message: Message.TextMessage) {
-  await bot?.telegram.deleteMessage(TELEGRAM_CHAT_ID, message.message_id);
 }
 
 export async function editMessage(

--- a/src/saveStats.ts
+++ b/src/saveStats.ts
@@ -1,6 +1,6 @@
-import { TransactionStatuses } from "israeli-bank-scrapers/lib/transactions";
-import { TransactionRow } from "./types";
-import { transactionList } from "./messages";
+import { TransactionStatuses } from "israeli-bank-scrapers/lib/transactions.js";
+import { TransactionRow } from "./types.js";
+import { transactionList } from "./messages.js";
 
 export interface SaveStats {
   /**

--- a/src/storage/azure-data-explorer.ts
+++ b/src/storage/azure-data-explorer.ts
@@ -8,7 +8,7 @@ import {
 import { sendError } from "../notifier.js";
 import { systemName } from "./../config.js";
 import { createLogger } from "./../utils/logger.js";
-import type KustoIngestClient from "azure-kusto-ingest/types/src/ingestClient.js";
+import type { KustoIngestClient } from "azure-kusto-ingest/types/src/ingestClient.js";
 import type { TransactionRow, TransactionStorage } from "../types.js";
 import { createSaveStats } from "../saveStats.js";
 

--- a/src/storage/utils.test.ts
+++ b/src/storage/utils.test.ts
@@ -2,8 +2,8 @@ import {
   Transaction,
   TransactionStatuses,
   TransactionTypes,
-} from "israeli-bank-scrapers/lib/transactions";
-import { transactionUniqueId, transactionHash } from "./utils";
+} from "israeli-bank-scrapers/lib/transactions.js";
+import { transactionUniqueId, transactionHash } from "./utils.js";
 import { CompanyTypes } from "israeli-bank-scrapers";
 
 const transaction1: Transaction = {

--- a/src/storage/utils.ts
+++ b/src/storage/utils.ts
@@ -1,6 +1,6 @@
 import { formatISO, parseISO, roundToNearestMinutes } from "date-fns";
 import type { CompanyTypes } from "israeli-bank-scrapers";
-import type { Transaction } from "israeli-bank-scrapers/lib/transactions";
+import type { Transaction } from "israeli-bank-scrapers/lib/transactions.js";
 
 /**
  * Generates a hash for a transaction that can be used to ~uniquely identify it.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
 import type { CompanyTypes } from "israeli-bank-scrapers";
-import type { Transaction } from "israeli-bank-scrapers/lib/transactions";
+import type { Transaction } from "israeli-bank-scrapers/lib/transactions.js";
 import type {
   ScraperScrapingResult,
   ScraperCredentials,
 } from "israeli-bank-scrapers";
-import { SaveStats } from "./saveStats";
+import { SaveStats } from "./saveStats.js";
 export type { Transaction };
 
 export type AccountConfig = ScraperCredentials & {

--- a/src/utils/currency.test.ts
+++ b/src/utils/currency.test.ts
@@ -1,4 +1,4 @@
-import { normalizeCurrency } from "./currency";
+import { normalizeCurrency } from "./currency.js";
 
 describe("normalizeCurrency", () => {
   it("should return undefined if currency is undefined", () => {


### PR DESCRIPTION
After merging #341 the scraper failed on runtime with the following error:

```
node:internal/modules/esm/resolve:265
    throw new ERR_MODULE_NOT_FOUND(
          ^

Error ***ERR_MODULE_NOT_FOUND***: Cannot find module '/app/dst/utils/currency' imported from /app/dst/messages.js
    at finalizeResolution (node:internal/modules/esm/resolve:265:11)
    at moduleResolve (node:internal/modules/esm/resolve:933:10)
    at defaultResolve (node:internal/modules/esm/resolve:1169:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:540:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:509:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:239:[38](https://github.com/daniel-hauser/moneyman/actions/runs/10759210526/job/29835599792#step:4:38))
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:96:[40](https://github.com/daniel-hauser/moneyman/actions/runs/10759210526/job/29835599792#step:4:40))
    at link (node:internal/modules/esm/module_job:95:36) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///app/dst/utils/currency'
}
```

This PR fixes the issue