### PR TITLE
feat: `chargedCurrency` now defaults to `originalCurrency`

### DIFF
--- a/src/storage/sheets.ts
+++ b/src/storage/sheets.ts
@@ -49,7 +49,9 @@ export function transactionRow(tx: TransactionRow): SheetRow {
     "scraped by": systemName,
     identifier: `${tx.identifier ?? ""}`,
     // Assuming the transaction is not pending, so we can use the original currency as the charged currency
-    chargedCurrency: normalizeCurrency(tx.chargedCurrency) || normalizeCurrency(tx.originalCurrency),
+    chargedCurrency:
+      normalizeCurrency(tx.chargedCurrency) ||
+      normalizeCurrency(tx.originalCurrency),
   };
 }
 

--- a/src/storage/sheets.ts
+++ b/src/storage/sheets.ts
@@ -48,7 +48,8 @@ export function transactionRow(tx: TransactionRow): SheetRow {
     "scraped at": currentDate,
     "scraped by": systemName,
     identifier: `${tx.identifier ?? ""}`,
-    chargedCurrency: normalizeCurrency(tx.chargedCurrency),
+    // Assuming the transaction is not pending, so we can use the original currency as the charged currency
+    chargedCurrency: normalizeCurrency(tx.chargedCurrency) || normalizeCurrency(tx.originalCurrency),
   };
 }
 


### PR DESCRIPTION
This pull request includes a change in the `transactionRow` function in the `src/storage/sheets.ts` file to handle the `chargedCurrency` more robustly by using the `originalCurrency` if `chargedCurrency` is not available.

Improvements to currency handling:

* [`src/storage/sheets.ts`](diffhunk://#diff-7b5df94ab18466419342c19861d0076aa3fe1f3cc917d0fda17aaa7ddfe33d78L51-R52): Modified the `transactionRow` function to use `normalizeCurrency(tx.chargedCurrency) || normalizeCurrency(tx.originalCurrency)` for the `chargedCurrency` field, assuming the transaction is not pending.