### PR TITLE
feat: parallelize saving to storages

### DIFF
--- a/src/__snapshots__/messages.test.ts.snap
+++ b/src/__snapshots__/messages.test.ts.snap
@@ -5,6 +5,7 @@ exports[`messages getSummaryMessages should not add empty groups 1`] = `
   "📝 Storage (TheTable)
 	0 added
 	0 skipped (0 existing, 0 pending)
+	took 0.00s
 	-----
 	Group2:
 		description1:	+10.00",
@@ -15,7 +16,8 @@ exports[`messages getSummaryMessages should not add empty groups 2`] = `
 [
   "📝 Storage (TheTable)
 	0 added
-	0 skipped (0 existing, 0 pending)",
+	0 skipped (0 existing, 0 pending)
+	took 0.00s",
 ]
 `;
 
@@ -38,10 +40,12 @@ exports[`messages getSummaryMessages should return a summary message 2`] = `
 [
   "📝 Storage 1 (TheTable)
 	1 added
-	0 skipped (0 existing, 0 pending)",
+	0 skipped (0 existing, 0 pending)
+	took 350.00s",
   "📝 Storage 2 (TheTable)
 	7 added
 	0 skipped (0 existing, 3 pending)
+	took 350.00s
 	-----
 	Group1:
 		description1:	+10.00",
@@ -80,6 +84,7 @@ exports[`messages getSummaryMessages should return a summary message with instal
   "📝 Storage 1 (TheTable)
 	2 added
 	0 skipped (0 existing, 0 pending)
+	took 0.00s
 	-----
 	SomeGroup:
 		should be +20:	+20.00

--- a/src/messages.test.ts
+++ b/src/messages.test.ts
@@ -103,7 +103,7 @@ describe("messages", () => {
       const summary = getSummaryMessages(results);
       expect(summary).toMatchSnapshot();
 
-      const saveSummaries = stats.map(statsString);
+      const saveSummaries = stats.map(stats => statsString(stats, 350000));
       expect(saveSummaries).toMatchSnapshot();
     });
 
@@ -115,7 +115,7 @@ describe("messages", () => {
       const summary = getSummaryMessages(results);
       expect(summary).toMatchSnapshot();
 
-      const saveSummaries = stats.map(statsString);
+      const saveSummaries = stats .map(stats => statsString(stats, 0));
       expect(saveSummaries).toMatchSnapshot();
     });
 
@@ -155,7 +155,7 @@ describe("messages", () => {
       const summary = getSummaryMessages(results);
       expect(summary).toMatchSnapshot();
 
-      const saveSummaries = stats.map(statsString);
+      const saveSummaries = stats .map(stats => statsString(stats, 0));
       expect(saveSummaries).toMatchSnapshot();
     });
 
@@ -208,7 +208,7 @@ describe("messages", () => {
       const summary = getSummaryMessages(results);
       expect(summary).toMatchSnapshot();
 
-      const saveSummaries = stats.map(statsString);
+      const saveSummaries = stats .map(stats => statsString(stats, 0));
       expect(saveSummaries).toMatchSnapshot();
     });
 
@@ -237,7 +237,7 @@ describe("messages", () => {
         }),
       ];
 
-      const saveSummaries = stats.map(statsString);
+      const saveSummaries = stats .map(stats => statsString(stats, 0));
       expect(saveSummaries).toMatchSnapshot();
     });
 
@@ -250,7 +250,7 @@ describe("messages", () => {
         }),
       ];
 
-      const saveSummaries = stats.map(statsString);
+      const saveSummaries = stats .map(stats => statsString(stats, 0));
       expect(saveSummaries).toMatchSnapshot();
     });
   });

--- a/src/messages.test.ts
+++ b/src/messages.test.ts
@@ -103,7 +103,7 @@ describe("messages", () => {
       const summary = getSummaryMessages(results);
       expect(summary).toMatchSnapshot();
 
-      const saveSummaries = stats.map(stats => statsString(stats, 350000));
+      const saveSummaries = stats.map((stats) => statsString(stats, 350000));
       expect(saveSummaries).toMatchSnapshot();
     });
 
@@ -115,7 +115,7 @@ describe("messages", () => {
       const summary = getSummaryMessages(results);
       expect(summary).toMatchSnapshot();
 
-      const saveSummaries = stats .map(stats => statsString(stats, 0));
+      const saveSummaries = stats.map((stats) => statsString(stats, 0));
       expect(saveSummaries).toMatchSnapshot();
     });
 
@@ -155,7 +155,7 @@ describe("messages", () => {
       const summary = getSummaryMessages(results);
       expect(summary).toMatchSnapshot();
 
-      const saveSummaries = stats .map(stats => statsString(stats, 0));
+      const saveSummaries = stats.map((stats) => statsString(stats, 0));
       expect(saveSummaries).toMatchSnapshot();
     });
 
@@ -208,7 +208,7 @@ describe("messages", () => {
       const summary = getSummaryMessages(results);
       expect(summary).toMatchSnapshot();
 
-      const saveSummaries = stats .map(stats => statsString(stats, 0));
+      const saveSummaries = stats.map((stats) => statsString(stats, 0));
       expect(saveSummaries).toMatchSnapshot();
     });
 
@@ -237,7 +237,7 @@ describe("messages", () => {
         }),
       ];
 
-      const saveSummaries = stats .map(stats => statsString(stats, 0));
+      const saveSummaries = stats.map((stats) => statsString(stats, 0));
       expect(saveSummaries).toMatchSnapshot();
     });
 
@@ -250,7 +250,7 @@ describe("messages", () => {
         }),
       ];
 
-      const saveSummaries = stats .map(stats => statsString(stats, 0));
+      const saveSummaries = stats.map((stats) => statsString(stats, 0));
       expect(saveSummaries).toMatchSnapshot();
     });
   });

--- a/src/saveStats.ts
+++ b/src/saveStats.ts
@@ -67,13 +67,14 @@ export function createSaveStats<TInit extends Partial<SaveStats>>(
   };
 }
 
-export function statsString(stats: SaveStats): string {
+export function statsString(stats: SaveStats, saveDurationMs: number): string {
   return `
 📝 ${stats.name}${stats.table ? ` (${stats.table})` : ""}
 \t${stats.added} added
 \t${stats.skipped} skipped (${stats.existing} existing, ${
     stats.pending
   } pending)
+\ttook ${(saveDurationMs / 1000).toFixed(2)}s
 ${highlightedTransactionsString(stats.highlightedTransactions, 1)}`.trim();
 }
 


### PR DESCRIPTION
This pull request includes changes to improve the performance of saving results and enhance the logging details. The most important changes include adding parallel processing for saving transactions, modifying the logging mechanism, and updating the `statsString` function to include the duration of the save operation.

Performance improvements:

* [`src/storage/index.ts`](diffhunk://#diff-189df448d4739484d3f18a1acd3d9f4b947564f111c3fb4ef7c14c284ec4c430L37-R63): Introduced parallel processing for saving transactions to different storages using the `parallel` function from the `async` library.

Logging enhancements:

* [`src/storage/index.ts`](diffhunk://#diff-189df448d4739484d3f18a1acd3d9f4b947564f111c3fb4ef7c14c284ec4c430R13-R15): Changed the logger initialization to use `baseLogger.extend(name)` for better logging context.

Function updates:

* [`src/saveStats.ts`](diffhunk://#diff-85a662bcd891b17b8aac7b509cb9e0a950f0f4910fa8646959362cfcf55b2fe2L70-R77): Updated the `statsString` function to include the duration of the save operation in seconds.