### PR TITLE
Add unit tests for getAccountTransactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/jest": "^29.5.14",
         "husky": "^9.1.6",
         "jest": "^29.7.0",
+        "jest-mock-extended": "^4.0.0-beta1",
         "patch-package": "^8.0.0",
         "prettier": "^3.3.3",
         "pretty-quick": "^4.0.0",
@@ -4170,6 +4171,20 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-mock-extended": {
+      "version": "4.0.0-beta1",
+      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-4.0.0-beta1.tgz",
+      "integrity": "sha512-MYcI0wQu3ceNhqKoqAJOdEfsVMamAFqDTjoLN5Y45PAG3iIm4WGnhOu0wpMjlWCexVPO71PMoNir9QrGXrnIlw==",
+      "dev": true,
+      "dependencies": {
+        "ts-essentials": "^10.0.2"
+      },
+      "peerDependencies": {
+        "@jest/globals": "^28.0.0 || ^29.0.0",
+        "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+        "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -6288,6 +6303,20 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-essentials": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.4.tgz",
+      "integrity": "sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/ts-jest": {
       "version": "29.2.5",
@@ -9829,6 +9858,15 @@
         "jest-util": "^29.7.0"
       }
     },
+    "jest-mock-extended": {
+      "version": "4.0.0-beta1",
+      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-4.0.0-beta1.tgz",
+      "integrity": "sha512-MYcI0wQu3ceNhqKoqAJOdEfsVMamAFqDTjoLN5Y45PAG3iIm4WGnhOu0wpMjlWCexVPO71PMoNir9QrGXrnIlw==",
+      "dev": true,
+      "requires": {
+        "ts-essentials": "^10.0.2"
+      }
+    },
     "jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -11426,6 +11464,13 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "ts-essentials": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.4.tgz",
+      "integrity": "sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==",
+      "dev": true,
+      "requires": {}
     },
     "ts-jest": {
       "version": "29.2.5",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/jest": "^29.5.14",
     "husky": "^9.1.6",
     "jest": "^29.7.0",
+    "jest-mock-extended": "^4.0.0-beta1",
     "patch-package": "^8.0.0",
     "prettier": "^3.3.3",
     "pretty-quick": "^4.0.0",

--- a/src/scraper/scrape.test.ts
+++ b/src/scraper/scrape.test.ts
@@ -1,0 +1,54 @@
+import { CompanyTypes, type ScraperOptions } from "israeli-bank-scrapers";
+import { getAccountTransactions } from "./scrape";
+import { mock, mockClear } from "jest-mock-extended";
+import { type BrowserContext, type Page } from "puppeteer";
+
+describe("getAccountTransactions", () => {
+  const onProgress = jest.fn();
+  const browserPage = mock<Page>();
+  const browserContext = mock<BrowserContext>({
+    newPage: jest.fn().mockResolvedValue(browserPage),
+  });
+
+  const account = {
+    companyId: CompanyTypes.hapoalim,
+    username: "username",
+    password: "password",
+  };
+
+  const scraperOptions: ScraperOptions = {
+    browserContext,
+    startDate: new Date(),
+    companyId: account.companyId,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClear(browserContext);
+    mockClear(browserPage);
+  });
+
+  it("should create a scraper and a page", async () => {
+    const result = await getAccountTransactions(
+      account,
+      scraperOptions,
+      onProgress,
+    );
+
+    expect(result).toBeDefined();
+    expect(result.success).toBeFalsy(); // because we didn't mock the scraper
+
+    expect(browserContext.newPage).toHaveBeenCalledTimes(1);
+    expect(browserPage.close).toHaveBeenCalledTimes(1);
+
+    expect(onProgress).toHaveBeenNthCalledWith(
+      1,
+      account.companyId,
+      "START_SCRAPING",
+    );
+    expect(onProgress).toHaveBeenLastCalledWith(
+      account.companyId,
+      "END_SCRAPING",
+    );
+  });
+});


### PR DESCRIPTION
- Introduce `jest-mock-extended` for mocking in tests
- add unit tests for the `getAccountTransactions` function to ensure the browserContext is properly used