### PR TITLE
feat: expose FUTURE_MONTHS as env var

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -40,6 +40,7 @@ jobs:
           -e DEBUG
           -e DAYS_BACK
           -e TZ
+          -e FUTURE_MONTHS
           -e WORKSHEET_NAME
           -e ACCOUNTS_JSON
           -e TELEGRAM_API_KEY
@@ -69,6 +70,7 @@ jobs:
           DEBUG: ""
           TZ: "Asia/Jerusalem"
           DAYS_BACK: ${{ github.event.inputs.daysBack }}
+          FUTURE_MONTHS: ${{ vars.FUTURE_MONTHS }}
           WORKSHEET_NAME: ${{ github.event.inputs.worksheetName }}
           ACCOUNTS_TO_SCRAPE: ${{ github.event.inputs.accountsToScrape }}
           ACCOUNTS_JSON: ${{ secrets.ACCOUNTS_JSON }}


### PR DESCRIPTION
FUTURE_MONTHS environment variable is not exposed making impossible to modify it without making a local modification of the scrape.yml file.


@daniel-hauser WDYT about add something similar for the cron?

```
on:
  schedule:
    - cron: ${{ vars.SCRAPE_CRON || '5 10,22 * * *' }}
```