### PR TITLE
Add missing `await`s to `index.ts`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,11 @@ async function runScraper(hooks: RunnerHooks) {
       scraperConfig,
       async (status, totalTime) => {
         logger("Status changed", { status, totalTime });
-        return hooks.onStatusChanged(status, totalTime);
+        return await hooks.onStatusChanged(status, totalTime);
       },
       async (e, caller) => {
         logger("Error while scraping", e);
-        return hooks.onError(e, caller);
+        return await hooks.onError(e, caller);
       },
     );
     logger("Scraping ended");

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -42,7 +42,7 @@ export async function scrapeAccounts(
   const results = await parallelLimit<AccountConfig, AccountScrapeResult[]>(
     accounts.map(
       (account, i) => async () =>
-        scrapeAccount(
+        await scrapeAccount(
           logger.extend(`#${i} (${account.companyId})`),
           account,
           {
@@ -56,7 +56,7 @@ export async function scrapeAccounts(
           },
           async (message, append = false) => {
             status[i] = append ? `${status[i]} ${message}` : message;
-            return scrapeStatusChanged?.(status);
+            return await scrapeStatusChanged?.(status);
           },
         ),
     ),


### PR DESCRIPTION
These missing `await`s basically cause the logger to do the delay in `editMessage` in parallel, triggering `429 Too Many Requests` messages from Telegram.

This should fix it.