### PR TITLE
feat: add headless param

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -8,7 +8,8 @@ on:
         required: false
         description: "Accounts to scrape (comma separated)"
       daysBack:
-        default: "10"
+        type: number
+        default: 10
         required: false
         description: "Days back to scrape"
       worksheetName:
@@ -16,9 +17,15 @@ on:
         required: false
         description: "The name of the worksheet to write to"
       parallelScrapes:
-        default: "1"
+        type: number
+        default: 1
         required: false
         description: "Number of parallel scrapes to run"
+      headed:
+        type: boolean
+        default: false
+        required: false
+        description: "Run scraper in headed mode"
       containerTag:
         default: "latest"
         required: false
@@ -72,6 +79,7 @@ jobs:
           -e WEB_POST_URL
           -e MAX_PARALLEL_SCRAPERS
           -e DOMAIN_TRACKING_ENABLED
+          -e HEADED_MODE
           ${{ steps.set-container-image.outputs.image }}
         env:
           DEBUG: ""
@@ -79,6 +87,7 @@ jobs:
           DAYS_BACK: ${{ github.event.inputs.daysBack }}
           WORKSHEET_NAME: ${{ github.event.inputs.worksheetName }}
           ACCOUNTS_TO_SCRAPE: ${{ github.event.inputs.accountsToScrape }}
+          HEADED_MODE: ${{ github.event.inputs.headed }}
           ACCOUNTS_JSON: ${{ secrets.ACCOUNTS_JSON }}
           TELEGRAM_API_KEY: ${{ secrets.TELEGRAM_API_KEY }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM ghcr.io/puppeteer/puppeteer
 
+# Install additional dependencies required for running Chrome
+RUN apt-get update && apt-get install -y \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY tsconfig.json .
@@ -11,4 +16,4 @@ RUN npm ci
 COPY ./src ./src
 RUN npm run build
 
-CMD ["npm", "run", "start"]
+CMD ["xvfb-run", "--auto-servernum", "--server-args='-screen 0 1280x720x24'", "npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM ghcr.io/puppeteer/puppeteer
 
-# Install additional dependencies required for running Chrome
-RUN apt-get update && apt-get install -y \
-    xvfb \
-    && rm -rf /var/lib/apt/lists/*
+ENV DISPLAY=:99
 
 WORKDIR /app
 
@@ -16,4 +13,6 @@ RUN npm ci
 COPY ./src ./src
 RUN npm run build
 
-CMD ["xvfb-run", "--auto-servernum", "--server-args='-screen 0 1280x720x24'", "npm", "run", "start"]
+# Start Xvfb and then run the application
+CMD Xvfb :99 -screen 0 1280x720x16 -ac -nolisten tcp -nolisten unix & \
+    npm run start

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ This app requires some technical skills, if you prefer a GUI app you can use [Ca
 **Important:**
 The current implementation assumes that you run the code on secure and trusted computers.
 
-**It’s a bad idea**
+**It's a bad idea**
 to put all your financial data and passwords in one place, especially with more than read-only access.
 
-By using moneyman, you acknowledge that you are taking full responsibility for the code quality and will use it only after you review the code and validate that it’s secure.
+By using moneyman, you acknowledge that you are taking full responsibility for the code quality and will use it only after you review the code and validate that it's secure.
 
 **Please use a proper secret management solution to save and pass the environment variables**
 
@@ -99,6 +99,7 @@ Example:
 | `PUPPETEER_EXECUTABLE_PATH` | `undefined`        | An ExecutablePath for the scraper. if undefined defaults to system.                                                                           |
 | `MAX_PARALLEL_SCRAPERS`     | `1`                | The maximum number of parallel scrapers to run                                                                                                |
 | `DOMAIN_TRACKING_ENABLED`   | ''                 | Enable tracking of all domains accessed during scraping                                                                                       |
+| `HEADED_MODE`               | `false`            | Run the browser in headed mode instead of headless.                                                                                           |
 
 ### Domain Security
 

--- a/src/scraper/browser.ts
+++ b/src/scraper/browser.ts
@@ -7,16 +7,15 @@ import puppeteer, {
 import { createLogger } from "../utils/logger.js";
 import { initDomainTracking } from "../security/domains.js";
 
-export const browserArgs = ["--disable-dev-shm-usage", "--no-sandbox"];
-export const browserExecutablePath =
-  process.env.PUPPETEER_EXECUTABLE_PATH || undefined;
+const { HEADED_MODE, PUPPETEER_EXECUTABLE_PATH } = process.env;
 
 const logger = createLogger("browser");
 
 export async function createBrowser(): Promise<Browser> {
   const options = {
-    args: browserArgs,
-    executablePath: browserExecutablePath,
+    args: ["--disable-dev-shm-usage", "--no-sandbox"],
+    headless: HEADED_MODE !== "true",
+    executablePath: PUPPETEER_EXECUTABLE_PATH || undefined,
   } satisfies PuppeteerLaunchOptions;
 
   logger("Creating browser", options);

--- a/src/scraper/browser.ts
+++ b/src/scraper/browser.ts
@@ -9,12 +9,23 @@ import { initDomainTracking } from "../security/domains.js";
 
 const { HEADED_MODE, PUPPETEER_EXECUTABLE_PATH } = process.env;
 
+const headless = HEADED_MODE !== "true";
+const args = headless
+  ? ["--disable-dev-shm-usage", "--no-sandbox"]
+  : [
+      "--disable-dev-shm-usage",
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      "--disable-gpu",
+      "--disable-software-rasterizer",
+    ];
+
 const logger = createLogger("browser");
 
 export async function createBrowser(): Promise<Browser> {
   const options = {
-    args: ["--disable-dev-shm-usage", "--no-sandbox"],
-    headless: HEADED_MODE !== "true",
+    args,
+    headless,
     executablePath: PUPPETEER_EXECUTABLE_PATH || undefined,
   } satisfies PuppeteerLaunchOptions;
 


### PR DESCRIPTION
This pull request includes several changes to the `scrape.yml` workflow, the `README.md` documentation, and the `browser.ts` file to introduce a new feature for running the scraper in headed mode. The most important changes include updates to the workflow configuration, environment variables, and browser launch options.

Updates to workflow configuration:

* [`.github/workflows/scrape.yml`](diffhunk://#diff-5f72821278fe20f161d8ff66811c979351ef53d21ea57391f3087ef336726bc1L11-R28): Added a new input parameter `headed` to allow running the scraper in headed mode. Updated existing parameters to include their types.

Updates to environment variables:

* [`.github/workflows/scrape.yml`](diffhunk://#diff-5f72821278fe20f161d8ff66811c979351ef53d21ea57391f3087ef336726bc1R82-R90): Added `HEADED_MODE` environment variable to the job configuration.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102): Updated the documentation to include the new `HEADED_MODE` environment variable in the example configuration.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R21): Fixed typographical errors by replacing curly quotes with straight quotes.

Browser launch options:

* [`src/scraper/browser.ts`](diffhunk://#diff-cf0eebf2ad750add3dedd6c9748830f50ea2a655ea7b0044646b2355967682a0L10-R18): Modified the `createBrowser` function to use the `HEADED_MODE` environment variable to determine whether to run the browser in headless mode.