### PR TITLE
feat: allow to block puppeteer requests

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -72,6 +72,8 @@ jobs:
           -e WEB_POST_URL
           -e MAX_PARALLEL_SCRAPERS
           -e DOMAIN_TRACKING_ENABLED
+          -e FIREWALL_SETTINGS
+          -e BLOCK_BY_DEFAULT
           ${{ steps.set-container-image.outputs.image }}
         env:
           DEBUG: ""
@@ -102,3 +104,5 @@ jobs:
           WEB_POST_URL: ${{ secrets.WEB_POST_URL }}
           MAX_PARALLEL_SCRAPERS: ${{ github.event.inputs.parallelScrapes || env.MAX_PARALLEL_SCRAPERS }}
           DOMAIN_TRACKING_ENABLED: ${{ vars.DOMAIN_TRACKING_ENABLED }}
+          FIREWALL_SETTINGS: ${{ secrets.FIREWALL_SETTINGS }}
+          BLOCK_BY_DEFAULT: ${{ vars.BLOCK_BY_DEFAULT }}

--- a/README.md
+++ b/README.md
@@ -111,7 +111,34 @@ When the scraping process is done, a message will be sent to the telegram chat w
 
 #### Domain Whitelisting
 
-TBD
+You can control which domains each scraper can access by configuring firewall rules. Each rule follows the format:
+
+```
+<companyId> <ALLOW|BLOCK> <domain>
+```
+
+Use the following env var to setup:
+| env variable name | description |
+| ----------------- | ----------- |
+| `FIREWALL_SETTINGS` | Multiline string with domain rules. Each line should follow the format: `<companyId> <ALLOW|BLOCK> <domain>` |
+| `BLOCK_BY_DEFAULT` | If truthy, all domains with no rule will be blocked by default. If falsy, all domains will be allowed by default |
+
+Example:
+
+```
+# Allow hapoalim to access these domains
+hapoalim ALLOW bankhapoalim.co.il
+# Block specific domain for visaCal
+visaCal BLOCK suspicious-domain.com
+```
+
+When a rule exists for a specific domain, the scraper will:
+
+- `ALLOW` - Allow the connection to proceed
+- `BLOCK` - Block the connection
+- If no rule exists for a domain, the default behavior is to allow the connection
+
+Rules support parent domain matching, so a rule for `example.com` will apply to `api.example.com` and `www.example.com` as well.
 
 ### Get notified in telegram
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ When a rule exists for a specific domain, the scraper will:
 - `BLOCK` - Block the connection
 - If no rule exists for a domain, the default behavior is to allow the connection
 
+> [!IMPORTANT]
+> All rules apply only if there is at least one rule for the scraper. scrapers with no rules will allow all connections
+
 Rules support parent domain matching, so a rule for `example.com` will apply to `api.example.com` and `www.example.com` as well.
 
 ### Get notified in telegram

--- a/patches/israeli-bank-scrapers+5.4.6.patch
+++ b/patches/israeli-bank-scrapers+5.4.6.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/israeli-bank-scrapers/lib/scrapers/base-isracard-amex.js b/node_modules/israeli-bank-scrapers/lib/scrapers/base-isracard-amex.js
+index 9bb5d71..dbe909d 100644
+--- a/node_modules/israeli-bank-scrapers/lib/scrapers/base-isracard-amex.js
++++ b/node_modules/israeli-bank-scrapers/lib/scrapers/base-isracard-amex.js
+@@ -247,9 +247,9 @@ class IsracardAmexBaseScraper extends _baseScraperWithBrowser.BaseScraperWithBro
+     this.page.on('request', request => {
+       if (request.url().includes('detector-dom.min.js')) {
+         debug('force abort for request do download detector-dom.min.js resource');
+-        void request.abort();
++        void request.abort(undefined, 1000);
+       } else {
+-        void request.continue();
++        void request.continue(undefined, 10);
+       }
+     });
+     await (0, _browser.maskHeadlessUserAgent)(this.page);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ process.on("uncaughtException", (err, origin) => {
   console.error("uncaughtException, sending error");
   sendError(`
 Caught exception: ${err}
+err.stack: ${err.stack}
 Exception origin: ${origin}`).catch((e) => {});
 });
 

--- a/src/runnerMetadata.ts
+++ b/src/runnerMetadata.ts
@@ -1,6 +1,6 @@
 import type { RunMetadata } from "./types";
 import { getUsedDomains } from "./security/domains.js";
-import { createLogger } from "./utils/logger.js";
+import { createLogger, metadataLogEntries } from "./utils/logger.js";
 
 const logger = createLogger("runner-metadata");
 
@@ -23,5 +23,5 @@ export async function reportRunMetadata(
     getUsedDomains(),
     getExternalIp(),
   ]);
-  await report({ domainsByCompany, networkInfo });
+  await report({ domainsByCompany, networkInfo, metadataLogEntries });
 }

--- a/src/security/__snapshots__/domains.test.ts.snap
+++ b/src/security/__snapshots__/domains.test.ts.snap
@@ -5,10 +5,10 @@ exports[`domains initDomainTracking should set up page request listener for rele
   "infra": [],
   "max": {
     "allowed": [
-      "bar.com",
+      "undefined(undefined) bar.com",
     ],
     "blocked": [
-      "baz.com",
+      "undefined(undefined) baz.com",
     ],
     "pages": [
       "foo.com/",

--- a/src/security/__snapshots__/domains.test.ts.snap
+++ b/src/security/__snapshots__/domains.test.ts.snap
@@ -5,13 +5,13 @@ exports[`domains initDomainTracking should set up page request listener for rele
   "infra": [],
   "max": {
     "allowed": [
-      "baz.com",
       "bar.com",
-      "foo.com",
     ],
-    "blocked": [],
+    "blocked": [
+      "baz.com",
+    ],
     "pages": [
-      "https://foo.com",
+      "foo.com/",
     ],
   },
 }

--- a/src/security/__snapshots__/domains.test.ts.snap
+++ b/src/security/__snapshots__/domains.test.ts.snap
@@ -2,17 +2,18 @@
 
 exports[`domains initDomainTracking should set up page request listener for relevant target types 1`] = `
 {
-  "infra": {
-    "domains": [],
-    "pages": [],
-  },
+  "infra": [],
   "max": {
-    "domains": [
+    "allowed": [
       "baz.com",
       "bar.com",
+      "foo.com",
     ],
+    "blocked": [],
     "pages": [
-      "https://foo.com",
+      "baz.com",
+      "bar.com",
+      "foo.com",
     ],
   },
 }

--- a/src/security/__snapshots__/domains.test.ts.snap
+++ b/src/security/__snapshots__/domains.test.ts.snap
@@ -11,9 +11,7 @@ exports[`domains initDomainTracking should set up page request listener for rele
     ],
     "blocked": [],
     "pages": [
-      "baz.com",
-      "bar.com",
-      "foo.com",
+      "https://foo.com",
     ],
   },
 }

--- a/src/security/domainRules.test.ts
+++ b/src/security/domainRules.test.ts
@@ -1,15 +1,11 @@
 import { CompanyTypes } from "israeli-bank-scrapers";
-import { DomainRuleManager, Rule, loadDomainRules } from "./domainRules.js";
+import { loadDomainRules } from "./domainRules.js";
 
 jest.mock("../utils/logger.js", () => ({
   createLogger: jest.fn(() => jest.fn()),
 }));
 
 describe("domainRules", () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
   describe("loadDomainRules", () => {
     it("should load rules from the provided string", () => {
       const ruleManager = loadDomainRules(

--- a/src/security/domainRules.test.ts
+++ b/src/security/domainRules.test.ts
@@ -1,0 +1,64 @@
+import { CompanyTypes } from "israeli-bank-scrapers";
+import { DomainRuleManager, Rule, loadDomainRules } from "./domainRules.js";
+
+jest.mock("../utils/logger.js", () => ({
+  createLogger: jest.fn(() => jest.fn()),
+}));
+
+describe("domainRules", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("loadDomainRules", () => {
+    it("should load rules from the provided string", () => {
+      const ruleManager = loadDomainRules(
+        `hapoalim ALLOW api.bankhapoalim.co.il`,
+      );
+      const result = ruleManager.getRule(
+        "https://api.bankhapoalim.co.il/login",
+        CompanyTypes.hapoalim,
+      );
+      expect(result).toBe("ALLOW");
+    });
+
+    it("should ignore comment lines and empty lines in rules string", () => {
+      const rulesString = `
+        # This is a comment
+        hapoalim ALLOW api.bankhapoalim.co.il
+        
+        # Another comment
+        leumi BLOCK api.leumi.co.il
+        # hapoalim BLOCK foo.bankhapoalim.co.il
+      `;
+      const ruleManager = loadDomainRules(rulesString);
+      for (const [company, domain, rule] of [
+        [CompanyTypes.hapoalim, "https://api.bankhapoalim.co.il", "ALLOW"],
+        [CompanyTypes.leumi, "https://api.leumi.co.il", "BLOCK"],
+        [CompanyTypes.hapoalim, "https://foo.bankhapoalim.co.il", "DEFAULT"],
+      ] as const) {
+        expect(ruleManager.getRule(domain, company)).toBe(rule);
+      }
+    });
+  });
+
+  describe("DomainRuleManager.getRule", () => {
+    const ruleManager = loadDomainRules(`
+            visaCal ALLOW cal-online.co.il
+            visaCal BLOCK google.com
+          `);
+
+    it.each([
+      ["ALLOW", "https://cal-online.co.il", CompanyTypes.visaCal],
+      ["BLOCK", "https://google.com", CompanyTypes.visaCal],
+      ["DEFAULT", "https://google.com", CompanyTypes.max],
+      ["BLOCK", "https://www.google.com", CompanyTypes.visaCal],
+      ["DEFAULT", "https://www.facebook.com", CompanyTypes.visaCal],
+      ["DEFAULT", "https://fonts.gstatic.com", CompanyTypes.visaCal],
+      ["ALLOW", "https://api.cal-online.co.il", CompanyTypes.visaCal],
+      ["ALLOW", "https://api.cal-online.co.il", CompanyTypes.visaCal],
+    ])("should return %s for %s under %s", (expected, url, company) => {
+      expect(ruleManager.getRule(url, company)).toBe(expected);
+    });
+  });
+});

--- a/src/security/domainRules.test.ts
+++ b/src/security/domainRules.test.ts
@@ -57,4 +57,35 @@ describe("domainRules", () => {
       expect(ruleManager.getRule(url, company)).toBe(expected);
     });
   });
+
+  describe("DomainRuleManager.hasAnyRule", () => {
+    it("should return true if company has rules defined", () => {
+      const ruleManager = loadDomainRules(`
+        hapoalim ALLOW api.bankhapoalim.co.il
+        leumi BLOCK api.leumi.co.il
+        visaCal ALLOW cal-online.co.il
+      `);
+
+      expect(ruleManager.hasAnyRule(CompanyTypes.hapoalim)).toBe(true);
+      expect(ruleManager.hasAnyRule(CompanyTypes.leumi)).toBe(true);
+      expect(ruleManager.hasAnyRule(CompanyTypes.visaCal)).toBe(true);
+    });
+
+    it("should return false if company has no rules defined", () => {
+      const ruleManager = loadDomainRules(`
+        hapoalim ALLOW api.bankhapoalim.co.il
+        leumi BLOCK api.leumi.co.il
+      `);
+
+      expect(ruleManager.hasAnyRule(CompanyTypes.max)).toBe(false);
+      expect(ruleManager.hasAnyRule(CompanyTypes.isracard)).toBe(false);
+    });
+
+    it("should return false with empty rules", () => {
+      const ruleManager = loadDomainRules("");
+
+      expect(ruleManager.hasAnyRule(CompanyTypes.hapoalim)).toBe(false);
+      expect(ruleManager.hasAnyRule(CompanyTypes.leumi)).toBe(false);
+    });
+  });
 });

--- a/src/security/domainRules.test.ts
+++ b/src/security/domainRules.test.ts
@@ -31,7 +31,6 @@ describe("domainRules", () => {
       for (const [company, domain, rule] of [
         [CompanyTypes.hapoalim, "https://api.bankhapoalim.co.il", "ALLOW"],
         [CompanyTypes.leumi, "https://api.leumi.co.il", "BLOCK"],
-        [CompanyTypes.hapoalim, "https://foo.bankhapoalim.co.il", "DEFAULT"],
       ] as const) {
         expect(ruleManager.getRule(domain, company)).toBe(rule);
       }

--- a/src/security/domainRules.test.ts
+++ b/src/security/domainRules.test.ts
@@ -1,14 +1,14 @@
 import { CompanyTypes } from "israeli-bank-scrapers";
-import { loadDomainRules } from "./domainRules.js";
+import { DomainRuleManager } from "./domainRules.js";
 
 jest.mock("../utils/logger.js", () => ({
   createLogger: jest.fn(() => jest.fn()),
 }));
 
 describe("domainRules", () => {
-  describe("loadDomainRules", () => {
+  describe("DomainRuleManager", () => {
     it("should load rules from the provided string", () => {
-      const ruleManager = loadDomainRules(
+      const ruleManager = new DomainRuleManager(
         `hapoalim ALLOW api.bankhapoalim.co.il`,
       );
       const result = ruleManager.getRule(
@@ -16,6 +16,24 @@ describe("domainRules", () => {
         CompanyTypes.hapoalim,
       );
       expect(result).toBe("ALLOW");
+    });
+
+    it("should load one-line rules", () => {
+      const ruleManager = new DomainRuleManager(
+        `hapoalim ALLOW api.bankhapoalim.co.il|hapoalim BLOCK fonts.gstatic.com`,
+      );
+      expect(
+        ruleManager.getRule(
+          "https://api.bankhapoalim.co.il/login",
+          CompanyTypes.hapoalim,
+        ),
+      ).toBe("ALLOW");
+      expect(
+        ruleManager.getRule(
+          "https://fonts.gstatic.com/login",
+          CompanyTypes.hapoalim,
+        ),
+      ).toBe("BLOCK");
     });
 
     it("should ignore comment lines and empty lines in rules string", () => {
@@ -27,7 +45,7 @@ describe("domainRules", () => {
         leumi BLOCK api.leumi.co.il
         # hapoalim BLOCK foo.bankhapoalim.co.il
       `;
-      const ruleManager = loadDomainRules(rulesString);
+      const ruleManager = new DomainRuleManager(rulesString);
       for (const [company, domain, rule] of [
         [CompanyTypes.hapoalim, "https://api.bankhapoalim.co.il", "ALLOW"],
         [CompanyTypes.leumi, "https://api.leumi.co.il", "BLOCK"],
@@ -38,20 +56,22 @@ describe("domainRules", () => {
   });
 
   describe("DomainRuleManager.getRule", () => {
-    const ruleManager = loadDomainRules(`
+    const ruleManager = new DomainRuleManager(`
             visaCal ALLOW cal-online.co.il
             visaCal BLOCK google.com
+            visaCal BLOCK facebook.com
+            visaCal BLOCK fonts.gstatic.com
           `);
 
     it.each([
       ["ALLOW", "https://cal-online.co.il", CompanyTypes.visaCal],
+      ["ALLOW", "https://api.cal-online.co.il", CompanyTypes.visaCal],
       ["BLOCK", "https://google.com", CompanyTypes.visaCal],
-      ["DEFAULT", "https://google.com", CompanyTypes.max],
       ["BLOCK", "https://www.google.com", CompanyTypes.visaCal],
-      ["DEFAULT", "https://www.facebook.com", CompanyTypes.visaCal],
-      ["DEFAULT", "https://fonts.gstatic.com", CompanyTypes.visaCal],
-      ["ALLOW", "https://api.cal-online.co.il", CompanyTypes.visaCal],
-      ["ALLOW", "https://api.cal-online.co.il", CompanyTypes.visaCal],
+      ["BLOCK", "https://www.facebook.com", CompanyTypes.visaCal],
+      ["BLOCK", "https://fonts.gstatic.com", CompanyTypes.visaCal],
+      ["ALLOW", "https://other.gstatic.com", CompanyTypes.visaCal], // Not blocked subdomain
+      ["ALLOW", "https://google.com", CompanyTypes.hapoalim], // Different company
     ])("should return %s for %s under %s", (expected, url, company) => {
       expect(ruleManager.getRule(url, company)).toBe(expected);
     });
@@ -59,7 +79,7 @@ describe("domainRules", () => {
 
   describe("DomainRuleManager.hasAnyRule", () => {
     it("should return true if company has rules defined", () => {
-      const ruleManager = loadDomainRules(`
+      const ruleManager = new DomainRuleManager(`
         hapoalim ALLOW api.bankhapoalim.co.il
         leumi BLOCK api.leumi.co.il
         visaCal ALLOW cal-online.co.il
@@ -71,7 +91,7 @@ describe("domainRules", () => {
     });
 
     it("should return false if company has no rules defined", () => {
-      const ruleManager = loadDomainRules(`
+      const ruleManager = new DomainRuleManager(`
         hapoalim ALLOW api.bankhapoalim.co.il
         leumi BLOCK api.leumi.co.il
       `);
@@ -81,7 +101,7 @@ describe("domainRules", () => {
     });
 
     it("should return false with empty rules", () => {
-      const ruleManager = loadDomainRules("");
+      const ruleManager = new DomainRuleManager("");
 
       expect(ruleManager.hasAnyRule(CompanyTypes.hapoalim)).toBe(false);
       expect(ruleManager.hasAnyRule(CompanyTypes.leumi)).toBe(false);

--- a/src/security/domainRules.ts
+++ b/src/security/domainRules.ts
@@ -7,6 +7,7 @@ export type Rule = "ALLOW" | "BLOCK" | "DEFAULT";
 
 export interface DomainRuleManager {
   getRule: (url: URL | string, company: CompanyTypes) => Rule;
+  isBlocked: (url: URL | string, company: CompanyTypes) => boolean;
   hasAnyRule(company: CompanyTypes): boolean;
 }
 
@@ -95,7 +96,9 @@ export function loadDomainRules(
       }
       return rule;
     },
-
+    isBlocked(url: URL | string, company: CompanyTypes): boolean {
+      return this.getRule(url, company) === "BLOCK";
+    },
     hasAnyRule(company: CompanyTypes): boolean {
       function hasRule(node: TrieNode): boolean {
         return (

--- a/src/security/domainRules.ts
+++ b/src/security/domainRules.ts
@@ -1,0 +1,109 @@
+import { CompanyTypes } from "israeli-bank-scrapers";
+import { createLogger } from "../utils/logger.js";
+
+const logger = createLogger("domain-rules");
+
+export type Rule = "ALLOW" | "BLOCK" | "DEFAULT";
+
+export interface DomainRuleManager {
+  getRule: (url: URL | string, company: CompanyTypes) => Rule;
+}
+
+interface TrieNode {
+  rules: Map<CompanyTypes, Rule>;
+  children: Map<string, TrieNode>;
+}
+
+/**
+ * Load domain rules
+ * Format: [company] [ALLOW/BLOCK] [domain]
+ * @returns A DomainRuleManager object with methods to check rules
+ */
+export function loadDomainRules(
+  rulesString: string = process.env.FIREWALL_SETTINGS || "",
+): DomainRuleManager {
+  const domainTrie: TrieNode = {
+    rules: new Map(),
+    children: new Map(),
+  };
+
+  /**
+   * Insert a domain rule into the trie
+   */
+  function insertRule(domain: string, company: CompanyTypes, rule: Rule): void {
+    // We store domains reversed in the trie (com.example.api) for efficient parent domain matching
+    const parts = domain.split(".").reverse();
+    let current = domainTrie;
+
+    for (const part of parts) {
+      if (!current.children.has(part)) {
+        current.children.set(part, { rules: new Map(), children: new Map() });
+      }
+      current = current.children.get(part)!;
+    }
+
+    // Set rule at the leaf node
+    current.rules.set(company, rule);
+    logger(`Inserted rule: ${company} ${rule} ${domain}`);
+  }
+
+  /**
+   * Look up a rule for a domain and company in the trie
+   * Returns the rule if found, or null for default behavior (allow)
+   */
+  function lookupRule(domain: string, company: CompanyTypes): Rule {
+    // We store domains reversed in the trie (com.example.api)
+    const parts = domain.split(".").reverse();
+
+    // Recursive function to traverse the trie and find the most specific rule
+    function findRule(node: TrieNode, index: number): Rule | null {
+      // Check if current node has a rule for this company
+      const currentRule = node.rules.get(company) ?? null;
+      if (index >= parts.length || !node.children.has(parts[index])) {
+        return currentRule;
+      }
+
+      // Go deeper in the trie
+      const childNode = node.children.get(parts[index])!;
+      const childRule = findRule(childNode, index + 1);
+
+      return childRule ?? currentRule;
+    }
+
+    return findRule(domainTrie, 0) ?? "DEFAULT";
+  }
+
+  for (const [companyId, action, domain] of parseDomainRules(rulesString)) {
+    if (action === "ALLOW" || action === "BLOCK" || action === "DEFAULT") {
+      insertRule(domain, companyId, action);
+    }
+  }
+
+  return {
+    /**
+     * Check a URL against the domain rules for a specific company
+     * @param url URL to check
+     * @param company Company ID to check rules for
+     * @returns "ALLOW" or "BLOCK" if a rule is found, "DEFAULT" if no rule exists
+     */
+    getRule: (url: URL | string, company: CompanyTypes): Rule => {
+      const { hostname } = typeof url === "string" ? new URL(url) : url;
+      const rule = lookupRule(hostname, company);
+      return rule;
+    },
+  };
+}
+
+function parseDomainRules(rulesString: string): [CompanyTypes, Rule, string][] {
+  return rulesString
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"))
+    .map((line) => line.split(" ").filter((part) => part.trim()))
+    .filter((parts): parts is [string, string, string] => parts.length === 3)
+    .map(([companyId, action, domain]) => [
+      companyId as CompanyTypes,
+      action as Rule,
+      domain,
+    ]);
+}

--- a/src/security/domainRules.ts
+++ b/src/security/domainRules.ts
@@ -7,6 +7,7 @@ export type Rule = "ALLOW" | "BLOCK" | "DEFAULT";
 
 export interface DomainRuleManager {
   getRule: (url: URL | string, company: CompanyTypes) => Rule;
+  hasAnyRule(company: CompanyTypes): boolean;
 }
 
 interface TrieNode {
@@ -93,6 +94,16 @@ export function loadDomainRules(
         return "BLOCK";
       }
       return rule;
+    },
+
+    hasAnyRule(company: CompanyTypes): boolean {
+      function hasRule(node: TrieNode): boolean {
+        return (
+          node.rules.has(company) ||
+          Array.from(node.children.values()).some(hasRule)
+        );
+      }
+      return hasRule(domainTrie);
     },
   };
 }

--- a/src/security/domainRules.ts
+++ b/src/security/domainRules.ts
@@ -89,6 +89,9 @@ export function loadDomainRules(
     getRule: (url: URL | string, company: CompanyTypes): Rule => {
       const { hostname } = typeof url === "string" ? new URL(url) : url;
       const rule = lookupRule(hostname, company);
+      if (rule === "DEFAULT" && process.env.BLOCK_BY_DEFAULT) {
+        return "BLOCK";
+      }
       return rule;
     },
   };

--- a/src/security/domains.test.ts
+++ b/src/security/domains.test.ts
@@ -7,6 +7,7 @@ import {
   Target,
   Page,
   HTTPRequest,
+  InterceptResolutionAction,
   Frame,
 } from "puppeteer";
 import { mock } from "jest-mock-extended";
@@ -82,12 +83,8 @@ describe("domains", () => {
         mock<Frame>({ url: () => "https://bar.com/hello" }),
       );
 
-      const mockRequestBar = mock<HTTPRequest>({
-        url: () => "https://bar.com",
-      });
-      const mockRequestBaz = mock<HTTPRequest>({
-        url: () => "https://baz.com",
-      });
+      const mockRequestBar = mockHttpRequest("https://bar.com");
+      const mockRequestBaz = mockHttpRequest("https://baz.com");
       const requestCallback = request as (r: HTTPRequest) => void;
       requestCallback(mockRequestBar);
       requestCallback(mockRequestBaz);
@@ -110,3 +107,14 @@ describe("domains", () => {
     });
   });
 });
+
+function mockHttpRequest(url: string): HTTPRequest {
+  const req = mock<HTTPRequest>();
+  req.url.mockReturnValue(url);
+  req.continue.mockResolvedValue();
+  req.abort.mockResolvedValue();
+  req.interceptResolutionState.mockReturnValue({
+    action: InterceptResolutionAction.None,
+  });
+  return req;
+}

--- a/src/security/domains.test.ts
+++ b/src/security/domains.test.ts
@@ -51,6 +51,11 @@ describe("domains", () => {
       page.url.mockReturnValue("https://foo.com");
       target.page.mockResolvedValue(page);
 
+      process.env.FIREWALL_SETTINGS = `
+      
+      ALLOW https://bar.com
+      BLOCK https://baz.com
+      `;
       await initDomainTracking(browserContext, CompanyTypes.max);
 
       const targetCreatedCallback = browserContext.on.mock.calls[0][1] as (
@@ -64,7 +69,11 @@ describe("domains", () => {
         request: HTTPRequest,
       ) => void;
 
-      for (const url of ["https://baz.com", "https://bar.com"]) {
+      for (const url of [
+        "https://baz.com",
+        "https://bar.com",
+        "https://foo.com",
+      ]) {
         const mockRequest = mock<HTTPRequest>();
         mockRequest.url.mockReturnValue(url);
         requestCallback(mockRequest);

--- a/src/security/domains.ts
+++ b/src/security/domains.ts
@@ -3,7 +3,6 @@ import { createLogger } from "../utils/logger.js";
 import { type BrowserContext, type HTTPRequest, TargetType } from "puppeteer";
 import { ClientRequestInterceptor } from "@mswjs/interceptors/ClientRequest";
 import { DomainRuleManager, loadDomainRules } from "./domainRules.js";
-import { sendError } from "../bot/notifier.js";
 
 const logger = createLogger("domain-security");
 
@@ -52,6 +51,7 @@ export async function initDomainTracking(
         case TargetType.BACKGROUND_PAGE: {
           logger(`Target created`, target.type());
           const page = await target.page();
+          page?.setRequestInterception(rules.hasAnyRule(companyId));
           page?.on("request", (request) => {
             const currentUrl = page.url();
             handleRequest(request, currentUrl, companyId, rules);

--- a/src/security/domains.ts
+++ b/src/security/domains.ts
@@ -66,27 +66,18 @@ export async function initDomainTracking(
                 return;
               }
 
-              const { action: resolution } = request.interceptResolutionState();
               if (ignoreUrl(url.hostname) || !rules.isBlocked(url, companyId)) {
                 addToKeyedSet(allowedByCompany, companyId, url.hostname);
                 logger(
                   `[${companyId}] Allowing ${pageUrl.hostname}->${reqString}`,
                 );
-                await request.continue().catch((error) => {
-                  logToMetadataFile(
-                    `[${companyId}][CONTINUE]: ${reqString} ${error.message}. interceptResolutionState was ${resolution}`,
-                  );
-                });
+                await request.continue(undefined, 100);
               } else {
                 addToKeyedSet(blockedByCompany, companyId, url.hostname);
                 logger(
                   `[${companyId}] Blocking ${pageUrl.hostname}->${reqString}`,
                 );
-                await request.abort().catch((error) => {
-                  logToMetadataFile(
-                    `[${companyId}][ABORT]: ${reqString} ${error.message}. interceptResolutionState was ${resolution}`,
-                  );
-                });
+                await request.abort(undefined, 100);
               }
             });
           } else {

--- a/src/security/domains.ts
+++ b/src/security/domains.ts
@@ -57,25 +57,25 @@ export async function initDomainTracking(
               const url = new URL(request.url());
               const pageUrl = new URL(page.url());
 
-              const reqString = `${request.method()}(${request.resourceType()}) ${url.hostname}`;
+              const reqKey = `${request.method()}(${request.resourceType()}) ${url.hostname}`;
               if (request.isInterceptResolutionHandled()) {
-                logger(`[${companyId}] Request already handled ${reqString}`);
+                logger(`[${companyId}] Request already handled ${reqKey}`);
                 logToMetadataFile(
-                  `[${companyId}] Request already handled ${reqString}`,
+                  `[${companyId}] Request already handled ${reqKey}`,
                 );
                 return;
               }
 
               if (ignoreUrl(url.hostname) || !rules.isBlocked(url, companyId)) {
-                addToKeyedSet(allowedByCompany, companyId, url.hostname);
+                addToKeyedSet(allowedByCompany, companyId, reqKey);
                 logger(
-                  `[${companyId}] Allowing ${pageUrl.hostname}->${reqString}`,
+                  `[${companyId}] Allowing ${pageUrl.hostname}->${reqKey}`,
                 );
                 await request.continue(undefined, 100);
               } else {
-                addToKeyedSet(blockedByCompany, companyId, url.hostname);
+                addToKeyedSet(blockedByCompany, companyId, reqKey);
                 logger(
-                  `[${companyId}] Blocking ${pageUrl.hostname}->${reqString}`,
+                  `[${companyId}] Blocking ${pageUrl.hostname}->${reqKey}`,
                 );
                 await request.abort(undefined, 100);
               }
@@ -83,12 +83,12 @@ export async function initDomainTracking(
           } else {
             page.on("request", async (request) => {
               const { hostname } = new URL(request.url());
+              const reqKey = `${request.method()}(${request.resourceType()}) ${hostname}`;
               if (!ignoreUrl(hostname)) {
-                addToKeyedSet(allowedByCompany, companyId, hostname);
+                addToKeyedSet(allowedByCompany, companyId, reqKey);
               }
-
               const pageUrl = new URL(page.url());
-              logger(`[${companyId}] ${pageUrl.hostname}->${hostname}`);
+              logger(`[${companyId}] ${pageUrl.hostname}->${reqKey}`);
             });
           }
 

--- a/src/security/domains.ts
+++ b/src/security/domains.ts
@@ -2,7 +2,7 @@ import { CompanyTypes } from "israeli-bank-scrapers";
 import { createLogger } from "../utils/logger.js";
 import { type BrowserContext, TargetType } from "puppeteer";
 import { ClientRequestInterceptor } from "@mswjs/interceptors/ClientRequest";
-import { loadDomainRules } from "./domainRules.js";
+import { DomainRuleManager } from "./domainRules.js";
 import { addToKeyedSet } from "../utils/collections.js";
 
 const logger = createLogger("domain-security");
@@ -29,7 +29,7 @@ export async function initDomainTracking(
   companyId: CompanyTypes,
 ): Promise<void> {
   if (process.env.DOMAIN_TRACKING_ENABLED) {
-    const rules = loadDomainRules();
+    const rules = new DomainRuleManager();
     browserContext.on("targetcreated", async (target) => {
       switch (target.type()) {
         case TargetType.PAGE:

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export type ImageWithCaption = {
 export type RunMetadata = {
   domainsByCompany: Partial<Record<CompanyTypes, unknown>>;
   networkInfo: unknown;
+  metadataLogEntries: Array<string>;
 };
 
 export interface RunnerHooks {

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -1,0 +1,17 @@
+export function addToKeyedSet<K, V>(map: Map<K, Set<V>>, key: K, value: V) {
+  if (!map.has(key)) {
+    map.set(key, new Set());
+  }
+  map.get(key)!.add(value);
+}
+
+export function addToKeyedMap<K, KItem, VItem>(
+  map: Map<K, Map<KItem, VItem>>,
+  key: K,
+  kv: [KItem, VItem],
+) {
+  if (!map.has(key)) {
+    map.set(key, new Map());
+  }
+  map.get(key)!.set(...kv);
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -6,6 +6,23 @@ export function createLogger(name: string) {
   return logger.extend(name);
 }
 
+/**
+ * Logs a message to stdout. Will be publicly visible when running in GitHub actions
+ * @unsafe
+ */
 export function logToPublicLog(message: string) {
   console.log(message);
+}
+
+export const metadataLogEntries: string[] = [];
+const metadataLogger = createLogger("metadataLogger");
+
+/**
+ * Logs a message to the metadata file sent to the chat
+ * @param message The message to log.
+ */
+export function logToMetadataFile(message: string) {
+  const date = new Date().toISOString();
+  metadataLogEntries.push(`[${date}] ${message}`);
+  metadataLogger(message);
 }


### PR DESCRIPTION
This pull request introduces a new feature for managing domain access rules for scrapers, including updates to the workflow configuration, documentation, and the addition of new domain rule logic and tests.

### Workflow Configuration Changes:

* [`.github/workflows/scrape.yml`](diffhunk://#diff-5f72821278fe20f161d8ff66811c979351ef53d21ea57391f3087ef336726bc1R75-R76): Added `FIREWALL_SETTINGS` and `BLOCK_BY_DEFAULT` environment variables to the workflow configuration. [[1]](diffhunk://#diff-5f72821278fe20f161d8ff66811c979351ef53d21ea57391f3087ef336726bc1R75-R76) [[2]](diffhunk://#diff-5f72821278fe20f161d8ff66811c979351ef53d21ea57391f3087ef336726bc1R107-R108)

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-R141): Updated the documentation to include details on configuring firewall rules using the `FIREWALL_SETTINGS` and `BLOCK_BY_DEFAULT` environment variables.

### Domain Rule Logic:

* [`src/security/domainRules.ts`](diffhunk://#diff-8222a8d12141f11f27a8ec938a89755f19a2456ee8a1c9c8e7a115b9899164dfR1-R112): Implemented the `DomainRuleManager` class to manage domain access rules, including methods for loading rules and checking access.

### Tests:

* [`src/security/domainRules.test.ts`](diffhunk://#diff-88ebd51f2305df73c8a012d16e974db25f5fadecac268b0dfb9d268aedc021e5R1-R64): Added tests for the `DomainRuleManager` to ensure correct loading and application of domain rules.

### Integration with Existing Code:

* [`src/security/domains.ts`](diffhunk://#diff-1798a6126920333a5a0f09a8ca29fb6fd474490e1145dbaf73998ec08a5e6b9dR5-R28): Integrated the new domain rule logic into the existing domain tracking and request handling functions, allowing for dynamic blocking or allowing of requests based on configured rules. [[1]](diffhunk://#diff-1798a6126920333a5a0f09a8ca29fb6fd474490e1145dbaf73998ec08a5e6b9dR5-R28) [[2]](diffhunk://#diff-1798a6126920333a5a0f09a8ca29fb6fd474490e1145dbaf73998ec08a5e6b9dR47) [[3]](diffhunk://#diff-1798a6126920333a5a0f09a8ca29fb6fd474490e1145dbaf73998ec08a5e6b9dL37-R57) [[4]](diffhunk://#diff-1798a6126920333a5a0f09a8ca29fb6fd474490e1145dbaf73998ec08a5e6b9dL48-R99) [[5]](diffhunk://#diff-1798a6126920333a5a0f09a8ca29fb6fd474490e1145dbaf73998ec08a5e6b9dL84-R130)