### PR TITLE
refactor(scraper): send failure screenshots faster

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,12 +42,13 @@ async function runScraper(hooks: RunnerHooks) {
       },
     );
     logger("Scraping ended");
-    await hooks.onResultsReady(results);
-
-    await sendFailureScreenShots((photos) => {
-      logger("Sending failure screenshot", { photos });
-      return hooks.failureScreenshotsHandler(photos);
-    });
+    await Promise.all([
+      hooks.onResultsReady(results),
+      sendFailureScreenShots((photos) => {
+        logger("Sending failure screenshot", { photos });
+        return hooks.failureScreenshotsHandler(photos);
+      }),
+    ]);
 
     await reportRunMetadata((metadata) => {
       logger("Reporting run metadata", metadata);

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,10 +44,7 @@ async function runScraper(hooks: RunnerHooks) {
     logger("Scraping ended");
     await Promise.all([
       hooks.onResultsReady(results),
-      sendFailureScreenShots((photos) => {
-        logger("Sending failure screenshot", { photos });
-        return hooks.failureScreenshotsHandler(photos);
-      }),
+      sendFailureScreenShots(hooks.failureScreenshotsHandler),
     ]);
 
     await reportRunMetadata((metadata) => {


### PR DESCRIPTION
Replaced sequential `await` calls for `hooks.onResultsReady(results)` and `sendFailureScreenShots` with a `Promise.all` to execute these operations in parallel, sending the failure screenshot without waiting for the storage operation to complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved performance by running certain post-scraping operations in parallel, resulting in faster completion times for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->