### PR TITLE
feat(scraper): add viewport size and navigation retry count

### DIFF
--- a/patches/israeli-bank-scrapers+5.4.6.patch
+++ b/patches/israeli-bank-scrapers+5.4.6.patch
@@ -68,41 +68,102 @@ index 9bb5d71..eca7d61 100644
      const validateUrl = `${this.servicesUrl}?reqName=ValidateIdData`;
      const validateRequest = {
 diff --git a/node_modules/israeli-bank-scrapers/lib/scrapers/base-scraper-with-browser.js b/node_modules/israeli-bank-scrapers/lib/scrapers/base-scraper-with-browser.js
-index 49895b5..72cb938 100644
+index 49895b5..3b49c9e 100644
 --- a/node_modules/israeli-bank-scrapers/lib/scrapers/base-scraper-with-browser.js
 +++ b/node_modules/israeli-bank-scrapers/lib/scrapers/base-scraper-with-browser.js
-@@ -23,8 +23,8 @@ function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol"
+@@ -23,9 +23,6 @@ function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol"
  function _toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
  function _objectWithoutProperties(e, t) { if (null == e) return {}; var o, r, i = _objectWithoutPropertiesLoose(e, t); if (Object.getOwnPropertySymbols) { var n = Object.getOwnPropertySymbols(e); for (r = 0; r < n.length; r++) o = n[r], t.indexOf(o) >= 0 || {}.propertyIsEnumerable.call(e, o) && (i[o] = e[o]); } return i; }
  function _objectWithoutPropertiesLoose(r, e) { if (null == r) return {}; var t = {}; for (var n in r) if ({}.hasOwnProperty.call(r, n)) { if (e.indexOf(n) >= 0) continue; t[n] = r[n]; } return t; }
 -const VIEWPORT_WIDTH = 1024;
 -const VIEWPORT_HEIGHT = 768;
-+const VIEWPORT_WIDTH = 1920;
-+const VIEWPORT_HEIGHT = 1080;
- const OK_STATUS = 200;
+-const OK_STATUS = 200;
  const debug = (0, _debug.getDebug)('base-scraper-with-browser');
  var LoginBaseResults = /*#__PURE__*/function (LoginBaseResults) {
-@@ -172,6 +172,7 @@ class BaseScraperWithBrowser extends _baseScraper.BaseScraper {
-   async navigateTo(url, page, timeout, waitUntil = 'load') {
-     const pageToUse = page || this.page;
-     if (!pageToUse) {
-+      debug('page is not initialized, exit');
+   LoginBaseResults["Success"] = "SUCCESS";
+@@ -82,9 +79,10 @@ class BaseScraperWithBrowser extends _baseScraper.BaseScraper {
+     _defineProperty(this, "page", void 0);
+   }
+   getViewPort() {
+-    return {
+-      width: VIEWPORT_WIDTH,
+-      height: VIEWPORT_HEIGHT
++    var _this$options$viewpor;
++    return (_this$options$viewpor = this.options.viewportSize) !== null && _this$options$viewpor !== void 0 ? _this$options$viewpor : {
++      width: 1024,
++      height: 768
+     };
+   }
+   async initialize() {
+@@ -169,21 +167,26 @@ class BaseScraperWithBrowser extends _baseScraper.BaseScraper {
+     debug('create a new browser page');
+     return browser.newPage();
+   }
+-  async navigateTo(url, page, timeout, waitUntil = 'load') {
+-    const pageToUse = page || this.page;
+-    if (!pageToUse) {
++  async navigateTo(url, waitUntil = 'load', retries = (_this$options$navigat => (_this$options$navigat = this.options.navigationRetryCount) !== null && _this$options$navigat !== void 0 ? _this$options$navigat : 0)()) {
++    var _this$page;
++    const response = await ((_this$page = this.page) === null || _this$page === void 0 ? void 0 : _this$page.goto(url, {
++      waitUntil
++    }));
++    if (response === null) {
++      // note: response will be null when navigating to same url while changing the hash part.
++      // the condition below will always accept null as valid result.
        return;
      }
-     const options = _objectSpread(_objectSpread({}, timeout === null ? null : {
-@@ -179,10 +180,14 @@ class BaseScraperWithBrowser extends _baseScraper.BaseScraper {
-     }), {}, {
-       waitUntil
-     });
-+    debug("Goto", url, options);
-     const response = await pageToUse.goto(url, options);
+-    const options = _objectSpread(_objectSpread({}, timeout === null ? null : {
+-      timeout
+-    }), {}, {
+-      waitUntil
+-    });
+-    const response = await pageToUse.goto(url, options);
 -
-+    debug("Goto ended", response.status());
-     // note: response will be null when navigating to same url while changing the hash part. the condition below will always accept null as valid result.
-     if (response !== null && (response === undefined || response.status() !== OK_STATUS)) {
-+      if (response.status() === 403) {
-+        return;
+-    // note: response will be null when navigating to same url while changing the hash part. the condition below will always accept null as valid result.
+-    if (response !== null && (response === undefined || response.status() !== OK_STATUS)) {
+-      throw new Error(`Error while trying to navigate to url ${url}`);
++    if (!response) {
++      throw new Error(`Error while trying to navigate to url ${url}, response is undefined`);
++    }
++    if (!response.ok()) {
++      if (retries > 0) {
++        debug(`Failed to navigate to url ${url}, retrying ${retries} more times`);
++        await this.navigateTo(url, waitUntil, retries - 1);
++      } else {
++        throw new Error(`Failed to navigate to url ${url}, status code: ${response.status()}`);
 +      }
-       throw new Error(`Error while trying to navigate to url ${url}`);
      }
    }
+ 
+@@ -213,7 +216,7 @@ class BaseScraperWithBrowser extends _baseScraper.BaseScraper {
+       await this.page.setUserAgent(loginOptions.userAgent);
+     }
+     debug('navigate to login url');
+-    await this.navigateTo(loginOptions.loginUrl, undefined, undefined, loginOptions.waitUntil);
++    await this.navigateTo(loginOptions.loginUrl, loginOptions.waitUntil);
+     if (loginOptions.checkReadiness) {
+       debug("execute 'checkReadiness' interceptor provided in login options");
+       await loginOptions.checkReadiness();
+diff --git a/node_modules/israeli-bank-scrapers/lib/scrapers/interface.d.ts b/node_modules/israeli-bank-scrapers/lib/scrapers/interface.d.ts
+index 0757de1..8c1bf48 100644
+--- a/node_modules/israeli-bank-scrapers/lib/scrapers/interface.d.ts
++++ b/node_modules/israeli-bank-scrapers/lib/scrapers/interface.d.ts
+@@ -131,6 +131,18 @@ export type ScraperOptions = ScraperBrowserOptions & {
+      * Please note: It will take more time to finish the process.
+      */
+     additionalTransactionInformation?: boolean;
++    /**
++     * Adjust the viewport size of the browser page.
++     * If not set, the default viewport size will be used.
++     */
++    viewportSize?: {
++        width: number;
++        height: number;
++    };
++    /**
++     * The number of times to retry the navigation in case of a failure (default 0)
++     */
++    navigationRetryCount?: number;
+ };
+ export interface OutputDataOptions {
+     /**

--- a/patches/israeli-bank-scrapers+5.4.6.patch
+++ b/patches/israeli-bank-scrapers+5.4.6.patch
@@ -127,7 +127,7 @@ index 49895b5..3b49c9e 100644
 +    }
 +    if (!response.ok()) {
 +      if (retries > 0) {
-+        debug(`Failed to navigate to url ${url}, retrying ${retries} more times`);
++        debug(`Failed to navigate to url ${url}, status code: ${response.status()}, retrying ${retries} more times`);
 +        await this.navigateTo(url, waitUntil, retries - 1);
 +      } else {
 +        throw new Error(`Failed to navigate to url ${url}, status code: ${response.status()}`);

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -9,6 +9,11 @@ import { parallelLimit } from "async";
 
 const logger = createLogger("scraper");
 
+export const scraperOptions: Partial<ScraperOptions> = {
+  navigationRetryCount: 3,
+  viewportSize: { width: 1920, height: 1080 },
+};
+
 export async function scrapeAccounts(
   {
     accounts,
@@ -53,8 +58,7 @@ export async function scrapeAccounts(
           companyId,
           futureMonthsToScrape: futureMonths,
           storeFailureScreenShotPath: getFailureScreenShotPath(companyId),
-          navigationRetryCount: 3,
-          viewportSize: { width: 1920, height: 1080 },
+          ...scraperOptions,
         },
         async (message, append = false) => {
           status[i] = append ? `${status[i]} ${message}` : message;

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -53,6 +53,8 @@ export async function scrapeAccounts(
           companyId,
           futureMonthsToScrape: futureMonths,
           storeFailureScreenShotPath: getFailureScreenShotPath(companyId),
+          navigationRetryCount: 3,
+          viewportSize: { width: 1920, height: 1080 },
         },
         async (message, append = false) => {
           status[i] = append ? `${status[i]} ${message}` : message;

--- a/src/test-scraper-access.ts
+++ b/src/test-scraper-access.ts
@@ -7,6 +7,7 @@ import {
 } from "./scraper/browser.js";
 import { createLogger } from "./utils/logger.js";
 import { getExternalIp } from "./runnerMetadata.js";
+import { scraperOptions } from "./scraper/index.js";
 
 const logger = createLogger("test-scraper-access");
 
@@ -95,6 +96,7 @@ describe("Sites access tests", () => {
         companyId,
         startDate: new Date(),
         browserContext: await createSecureBrowserContext(browser, companyId),
+        ...scraperOptions,
       });
 
       const result = await scraper.scrape({


### PR DESCRIPTION
Integrate my changes proposed in Added in https://github.com/eshaham/israeli-bank-scrapers/pull/928, patching moneyman until merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring browser viewport size and navigation retry count during scraping.
- **Bug Fixes**
  - Improved error handling and robustness for browser navigation, including retries on failed attempts.
- **Refactor**
  - Enhanced navigation logic for more reliable page loading and resource handling.
- **Chores**
  - Standardized browser viewport to 1920x1080 and set navigation retries to 3 for scraping sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->