### PR TITLE
scrape: allow 8 parallel scrapers

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -33,7 +33,7 @@ on:
     - cron: "5 10,22 * * *"
 env:
   REGISTRY: ghcr.io
-  MAX_PARALLEL_SCRAPERS: 3
+  MAX_PARALLEL_SCRAPERS: 8
 jobs:
   scrape:
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Increased the default concurrency limit for parallel scrapers in workflow runs, allowing up to 8 scrapers to run simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->