### PR TITLE
Add GitHub Actions step to create a release with Docker image details

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           **Tag:** \`sha-${{ github.sha }}\`
           **Commit:** ${{ github.sha }}
 
-          Pull with: \`docker pull ${{ env.REGISTRY }}/${{ github.repository }}:sha-${{ github.sha }}\`" \
+          Pull with: \`docker pull ${{ env.REGISTRY }}/${{ steps.normalize-repository-name.outputs.repository }}:sha-${{ github.sha }}\`" \
             --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,3 +60,17 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Create Release
+        run: |
+          gh release create sha-${{ github.sha }} \
+            --title "Release sha-${{ github.sha }}" \
+            --notes "🐳 Docker image published to GitHub Container Registry
+
+          **Image:** \`${{ env.REGISTRY }}/${{ github.repository }}:latest\`
+          **Tag:** \`sha-${{ github.sha }}\`
+          **Commit:** ${{ github.sha }}
+
+          Pull with: \`docker pull ${{ env.REGISTRY }}/${{ github.repository }}:latest\`"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,10 +67,11 @@ jobs:
             --title "Release sha-${{ github.sha }}" \
             --notes "🐳 Docker image published to GitHub Container Registry
 
-          **Image:** \`${{ env.REGISTRY }}/${{ github.repository }}:latest\`
+          **Image:** \`${{ env.REGISTRY }}/${{ github.repository }}:sha-${{ github.sha }}\`
           **Tag:** \`sha-${{ github.sha }}\`
           **Commit:** ${{ github.sha }}
 
-          Pull with: \`docker pull ${{ env.REGISTRY }}/${{ github.repository }}:latest\`"
+          Pull with: \`docker pull ${{ env.REGISTRY }}/${{ github.repository }}:sha-${{ github.sha }}\`" \
+            --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It is easier and common to use the Releases when using GitHub API to check the project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to allow automated release creation as part of the build. Releases are created automatically with the image location, image tag tied to the commit SHA, commit reference, and pull instructions. Workflow permissions adjusted to enable release publishing using the repository token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->