### PR TITLE
fix: disable Docker attestation to prevent cleanup from breaking image manifests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
 
       - name: Create Release
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -261,6 +261,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
 
       - name: Get image size
         if: needs.prepare.outputs.build_needed == 'true'


### PR DESCRIPTION
## Summary

Disable Docker attestation (provenance + SBOM) in `docker/build-push-action` to prevent the daily cleanup workflow from breaking the `latest` image tag.

Fixes #789

## Changes

- **`build.yml`**: Added `provenance: false` and `sbom: false` to the Docker build-push step
- **`pr-build.yml`**: Same change for the internal PR image build (consistency)

## Why

`docker/build-push-action@v6` generates attestation manifests as **untagged** child package versions in GHCR. The `cleanup-images.yml` workflow deletes all untagged packages daily, which removes these child manifests and breaks the parent manifest list that `latest` points to.

After this change:
- Images are pushed as simple flat manifests (no manifest list wrapper)
- No untagged child manifests are created
- The cleanup workflow can safely delete untagged packages
- Image size in GHCR will accurately show ~383MB instead of ~1.3GB

## Testing

The PR build will produce a `pr-XXX` tagged image — verify it can be pulled and run successfully before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configurations to optimize Docker image build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->