### PR TITLE
feat: Add kernel.sh cloud browser support with lightweight Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
       - ".eslintrc.js"
       - ".prettierrc.js"
       - "Dockerfile"
+      - "Dockerfile.kernel"
       - "docker-compose.yml"
       - ".github/workflows/build.yml"
   workflow_dispatch:
@@ -98,6 +99,27 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+
+      - name: Extract Docker metadata for kernel image
+        id: meta-kernel
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.normalize-repository-name.outputs.repository }}-kernel
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=sha,format=short
+
+      - name: Build and push kernel Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.kernel
+          push: true
+          tags: ${{ steps.meta-kernel.outputs.tags }}
+          labels: ${{ steps.meta-kernel.outputs.labels }}
           provenance: false
           sbom: false
 

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -13,19 +13,26 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        package-name:
+          - ${{ github.event.repository.name }}
+          - ${{ github.event.repository.name }}-kernel
     steps:
       - name: Delete old Docker images
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           script: |
             const repo = context.repo.repo;
             const owner = context.repo.owner;
+            const packageName = '${{ matrix.package-name }}';
 
             try {
               // Get all package versions for the repository
               const packages = await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
                 package_type: 'container',
-                package_name: repo,
+                package_name: packageName,
                 org: owner,
                 per_page: 100
               });
@@ -47,7 +54,7 @@ jobs:
                   try {
                     await github.rest.packages.deletePackageVersionForOrg({
                       package_type: 'container',
-                      package_name: repo,
+                      package_name: packageName,
                       org: owner,
                       package_version_id: pkg.id
                     });
@@ -85,7 +92,7 @@ jobs:
                 try {
                   await github.rest.packages.deletePackageVersionForOrg({
                     package_type: 'container',
-                    package_name: repo,
+                    package_name: packageName,
                     org: owner,
                     package_version_id: pkg.id
                   });
@@ -107,7 +114,7 @@ jobs:
                 try {
                   const packages = await github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
                     package_type: 'container',
-                    package_name: repo,
+                    package_name: packageName,
                     username: owner,
                     per_page: 100
                   });
@@ -129,7 +136,7 @@ jobs:
                       try {
                         await github.rest.packages.deletePackageVersionForUser({
                           package_type: 'container',
-                          package_name: repo,
+                          package_name: packageName,
                           username: owner,
                           package_version_id: pkg.id
                         });
@@ -167,7 +174,7 @@ jobs:
                     try {
                       await github.rest.packages.deletePackageVersionForUser({
                         package_type: 'container',
-                        package_name: repo,
+                        package_name: packageName,
                         username: owner,
                         package_version_id: pkg.id
                       });

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -34,6 +34,16 @@ jobs:
           tag: pr-${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Delete kernel Docker image
+        if: steps.pr-check.outputs.is_external == 'false'
+        uses: chipkent/action-cleanup-package@v1.0.3
+        continue-on-error: true
+        id: delete-kernel-image
+        with:
+          package-name: ${{ github.event.repository.name }}-kernel
+          tag: pr-${{ github.event.pull_request.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Update original comment about image push
         if: steps.pr-check.outputs.is_external == 'false'
         uses: actions/github-script@v8

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -65,14 +65,18 @@ jobs:
 
               // Find the comment about Docker image being built
               const imageComment = comments.data.find(comment =>
-                comment.body.includes('🐳 Docker image built and pushed:') &&
+                comment.body.includes('🐳 Docker image') &&
                 comment.body.includes(imageName)
               );
 
               if (imageComment) {
-                const deletionStatus = '${{ steps.delete-image.outcome }}' === 'success' ?
-                  '🗑️ **Image deleted** from registry' :
-                  '⚠️ **Image cleanup attempted** (may not have existed)';
+                const imageStatus = '${{ steps.delete-image.outcome }}' === 'success';
+                const kernelStatus = '${{ steps.delete-kernel-image.outcome }}' === 'success';
+                const allSuccess = imageStatus && kernelStatus;
+
+                const deletionStatus = allSuccess ?
+                  '🗑️ **Images deleted** from registry' :
+                  '⚠️ **Image cleanup attempted** (some may not have existed)';
 
                 // Extract just the first line (image info) for strikethrough, exclude the link
                 const firstLine = imageComment.body.split('\n')[0];

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -290,10 +290,12 @@ jobs:
         id: image-size
         run: |
           IMAGE_TAG="${{ steps.meta.outputs.tags }}"
+          docker pull "$IMAGE_TAG" >/dev/null
           IMAGE_SIZE=$(docker images --format "{{.Size}}" "$IMAGE_TAG")
           echo "size=$IMAGE_SIZE" >> $GITHUB_OUTPUT
 
           KERNEL_TAG="${{ steps.meta-kernel.outputs.tags }}"
+          docker pull "$KERNEL_TAG" >/dev/null
           KERNEL_SIZE=$(docker images --format "{{.Size}}" "$KERNEL_TAG")
           echo "kernel_size=$KERNEL_SIZE" >> $GITHUB_OUTPUT
 
@@ -441,16 +443,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=docker,dest=/tmp/image.tar
-
-      - name: Build kernel Docker image
-        if: needs.prepare.outputs.build_needed == 'true'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile.kernel
-          push: false
-          tags: ghcr.io/${{ needs.prepare.outputs.repository }}-kernel:pr-${{ github.event.pull_request.number }}
-          outputs: type=docker,dest=/tmp/image-kernel.tar
 
       - name: Get image and artifact sizes
         if: needs.prepare.outputs.build_needed == 'true'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -40,6 +40,7 @@ jobs:
             ".eslintrc.js"
             ".prettierrc.js"
             "Dockerfile"
+            "Dockerfile.kernel"
             "docker-compose.yml"
             ".github/workflows/pr-build.yml"
           )
@@ -264,6 +265,26 @@ jobs:
           provenance: false
           sbom: false
 
+      - name: Extract Docker metadata for kernel PR image
+        if: needs.prepare.outputs.build_needed == 'true'
+        id: meta-kernel
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ needs.prepare.outputs.repository }}-kernel
+          tags: type=ref,event=pr
+
+      - name: Build and push kernel Docker image
+        if: needs.prepare.outputs.build_needed == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.kernel
+          push: true
+          tags: ${{ steps.meta-kernel.outputs.tags }}
+          labels: ${{ steps.meta-kernel.outputs.labels }}
+          provenance: false
+          sbom: false
+
       - name: Get image size
         if: needs.prepare.outputs.build_needed == 'true'
         id: image-size
@@ -290,7 +311,9 @@ jobs:
 
             const imageSize = process.env.IMAGE_SIZE || 'Unknown';
 
-            const comment = `🐳 Docker image built and pushed: \`${imageName}\`
+            const comment = `🐳 Docker images built and pushed:
+            - \`${imageName}\`
+            - \`ghcr.io/${owner}/${repository}-kernel:${imageTag}\`
 
             📏 **Size**: ${imageSize}
             🔗 [View on GitHub Container Registry](${ghcrUrl})`;
@@ -409,6 +432,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=docker,dest=/tmp/image.tar
+
+      - name: Build kernel Docker image
+        if: needs.prepare.outputs.build_needed == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.kernel
+          push: false
+          tags: ghcr.io/${{ needs.prepare.outputs.repository }}-kernel:pr-${{ github.event.pull_request.number }}
+          outputs: type=docker,dest=/tmp/image-kernel.tar
 
       - name: Get image and artifact sizes
         if: needs.prepare.outputs.build_needed == 'true'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -285,21 +285,26 @@ jobs:
           provenance: false
           sbom: false
 
-      - name: Get image size
+      - name: Get image sizes
         if: needs.prepare.outputs.build_needed == 'true'
         id: image-size
         run: |
           IMAGE_TAG="${{ steps.meta.outputs.tags }}"
-          # Get image size in human-readable format
           IMAGE_SIZE=$(docker images --format "{{.Size}}" "$IMAGE_TAG")
           echo "size=$IMAGE_SIZE" >> $GITHUB_OUTPUT
-          echo "Image size: $IMAGE_SIZE"
+
+          KERNEL_TAG="${{ steps.meta-kernel.outputs.tags }}"
+          KERNEL_SIZE=$(docker images --format "{{.Size}}" "$KERNEL_TAG")
+          echo "kernel_size=$KERNEL_SIZE" >> $GITHUB_OUTPUT
+
+          echo "Image size: $IMAGE_SIZE, Kernel size: $KERNEL_SIZE"
 
       - name: Comment on PR with image information
         if: needs.prepare.outputs.build_needed == 'true'
         uses: actions/github-script@v8
         env:
           IMAGE_SIZE: ${{ steps.image-size.outputs.size }}
+          KERNEL_SIZE: ${{ steps.image-size.outputs.kernel_size }}
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -307,15 +312,19 @@ jobs:
             const owner = context.repo.owner.toLowerCase();
             const imageTag = `pr-${prNumber}`;
             const imageName = `ghcr.io/${owner}/${repository}:${imageTag}`;
+            const kernelImageName = `ghcr.io/${owner}/${repository}-kernel:${imageTag}`;
             const ghcrUrl = `https://github.com/${owner}/${repository}/pkgs/container/${repository}`;
 
             const imageSize = process.env.IMAGE_SIZE || 'Unknown';
+            const kernelSize = process.env.KERNEL_SIZE || 'Unknown';
 
             const comment = `🐳 Docker images built and pushed:
-            - \`${imageName}\`
-            - \`ghcr.io/${owner}/${repository}-kernel:${imageTag}\`
 
-            📏 **Size**: ${imageSize}
+            | Image | Tag | Size |
+            |-------|-----|------|
+            | \`${repository}\` | \`${imageTag}\` | ${imageSize} |
+            | \`${repository}-kernel\` | \`${imageTag}\` | ${kernelSize} |
+
             🔗 [View on GitHub Container Registry](${ghcrUrl})`;
 
             // Find existing comment about Docker image to update instead of creating new one
@@ -326,7 +335,7 @@ jobs:
             });
 
             const existingComment = comments.data.find(c =>
-              c.body.includes('🐳 Docker image built and pushed:') &&
+              c.body.includes('🐳 Docker image') &&
               c.body.includes(`pr-${prNumber}`)
             );
 

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -7,6 +7,11 @@ on:
         default: "latest"
         required: false
         description: "Container tag to use (e.g., 'latest', 'pr-123' for PR #123)"
+      useKernelBrowser:
+        description: "Use kernel cloud browser container (no local Chromium)"
+        type: boolean
+        required: false
+        default: false
       sendNewConfigToTg:
         description: "Send current config as config.txt via Telegram (true/false)"
         type: boolean
@@ -29,7 +34,13 @@ jobs:
         run: echo "repository=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - id: set-container-image
-        run: echo "image=${{ env.REGISTRY }}/${{ steps.normalize-repository-name.outputs.repository }}:${{ github.event.inputs.containerTag || 'latest' }}" >> $GITHUB_OUTPUT
+        run: |
+          TAG="${{ github.event.inputs.containerTag || 'latest' }}"
+          if [ "${{ github.event.inputs.useKernelBrowser }}" = "true" ]; then
+            echo "image=${{ env.REGISTRY }}/${{ steps.normalize-repository-name.outputs.repository }}-kernel:${TAG}" >> $GITHUB_OUTPUT
+          else
+            echo "image=${{ env.REGISTRY }}/${{ steps.normalize-repository-name.outputs.repository }}:${TAG}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Pull container image
         run: docker pull ${{ steps.set-container-image.outputs.image }}
@@ -41,9 +52,11 @@ jobs:
           -e DEBUG
           -e TZ
           -e SEND_NEW_CONFIG_TO_TG
+          ${{ github.event.inputs.useKernelBrowser == 'true' && '-e KERNEL_API_KEY' || '' }}
           ${{ steps.set-container-image.outputs.image }}
         env:
           MONEYMAN_CONFIG: ${{ secrets.MONEYMAN_CONFIG }}
           DEBUG: ${{ github.event.inputs.DEBUG || '' }}
           TZ: "Asia/Jerusalem"
           SEND_NEW_CONFIG_TO_TG: ${{ github.event.inputs.sendNewConfigToTg }}
+          KERNEL_API_KEY: ${{ secrets.KERNEL_API_KEY }}

--- a/.github/workflows/test-connections.yml
+++ b/.github/workflows/test-connections.yml
@@ -10,6 +10,7 @@ on:
       - "package-lock.json"
       - "tsconfig.json"
       - "Dockerfile"
+      - "Dockerfile.kernel"
       - ".github/workflows/test-connections.yml"
 jobs:
   test-connections:

--- a/Dockerfile.kernel
+++ b/Dockerfile.kernel
@@ -28,9 +28,10 @@ COPY --from=builder /app/package-lock.json ./
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dst ./dst
 COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/
+COPY --chmod=755 docker-entrypoint-kernel.sh /usr/local/bin/
 
 ENV MONEYMAN_UNSAFE_STDOUT=false
 ENV MONEYMAN_LOG_FILE_PATH=/tmp/moneyman.log
 ENV MONEYMAN_PUBLIC_LOG_FD=3
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["docker-entrypoint-kernel.sh"]

--- a/Dockerfile.kernel
+++ b/Dockerfile.kernel
@@ -1,0 +1,36 @@
+FROM node:slim AS builder
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+WORKDIR /app
+
+COPY package.json package-lock.json tsconfig.json ./
+COPY patches ./patches
+
+RUN npm ci
+
+COPY src ./src
+
+RUN npm run build && \
+    npm prune --omit=dev && \
+    npm cache clean --force && \
+    rm -rf src
+
+FROM node:slim AS runner
+
+ENV NODE_ENV=production
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+WORKDIR /app
+
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/package-lock.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dst ./dst
+COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/
+
+ENV MONEYMAN_UNSAFE_STDOUT=false
+ENV MONEYMAN_LOG_FILE_PATH=/tmp/moneyman.log
+ENV MONEYMAN_PUBLIC_LOG_FD=3
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-entrypoint-kernel.sh
+++ b/docker-entrypoint-kernel.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if [ -z "$KERNEL_API_KEY" ]; then
+  echo "ERROR: KERNEL_API_KEY is required for the kernel image."
+  echo "Use the standard moneyman image for local browser support."
+  exit 1
+fi
+
+exec docker-entrypoint.sh "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@actual-app/api": "^26.2.0",
         "@mswjs/interceptors": "^0.41.3",
+        "@onkernel/sdk": "^0.43.0",
         "@telegraf/entity": "^0.7.0",
         "async": "^3.2.6",
         "azure-kusto-data": "^7.0.4",
@@ -1605,6 +1606,12 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
       }
+    },
+    "node_modules/@onkernel/sdk": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@onkernel/sdk/-/sdk-0.43.0.tgz",
+      "integrity": "sha512-pvveMdVCzjtVqNeLI+yk+VBTMaIvRe/jevvKJqnHl2svlDxvT7Z0mNFeiAWsDLeh1TQL92aWEKZoyEVxRniO9w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",
@@ -9250,6 +9257,11 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
       }
+    },
+    "@onkernel/sdk": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@onkernel/sdk/-/sdk-0.43.0.tgz",
+      "integrity": "sha512-pvveMdVCzjtVqNeLI+yk+VBTMaIvRe/jevvKJqnHl2svlDxvT7Z0mNFeiAWsDLeh1TQL92aWEKZoyEVxRniO9w=="
     },
     "@open-draft/deferred-promise": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@actual-app/api": "^26.2.0",
     "@mswjs/interceptors": "^0.41.3",
+    "@onkernel/sdk": "^0.43.0",
     "@telegraf/entity": "^0.7.0",
     "async": "^3.2.6",
     "azure-kusto-data": "^7.0.4",

--- a/src/scraper/browser.ts
+++ b/src/scraper/browser.ts
@@ -69,7 +69,10 @@ export async function createSecureBrowserContext(
 ): Promise<BrowserContext> {
   const context = await browser.createBrowserContext();
   await initDomainTracking(context, companyId);
-  await initCloudflareSkipping(context);
+  // Kernel cloud browsers have managed stealth mode, skip local bot evasion.
+  if (!useKernelBrowser) {
+    await initCloudflareSkipping(context);
+  }
   return context;
 }
 

--- a/src/scraper/browser.ts
+++ b/src/scraper/browser.ts
@@ -25,7 +25,23 @@ export const browserExecutablePath =
 
 const logger = createLogger("browser");
 
-export async function createBrowser(): Promise<Browser> {
+async function createKernelBrowser(): Promise<Browser> {
+  const Kernel = (await import("@onkernel/sdk")).default;
+  const kernel = new Kernel();
+  const kernelBrowser = await kernel.browsers.create({
+    stealth: true,
+    viewport: { width: 1920, height: 1080 },
+  });
+  logger("Connecting to Kernel cloud browser", {
+    cdp_ws_url: kernelBrowser.cdp_ws_url,
+  });
+  return puppeteer.connect({
+    browserWSEndpoint: kernelBrowser.cdp_ws_url,
+    defaultViewport: null,
+  });
+}
+
+function createLocalBrowser(): Promise<Browser> {
   const options = {
     args: browserArgs,
     executablePath: browserExecutablePath,
@@ -33,8 +49,18 @@ export async function createBrowser(): Promise<Browser> {
     ignoreDefaultArgs: ["--enable-automation"],
   } satisfies PuppeteerLaunchOptions;
 
-  logger("Creating browser", options);
+  logger("Creating local browser", options);
   return puppeteer.launch(options);
+}
+
+export const useKernelBrowser = Boolean(process.env.KERNEL_API_KEY);
+
+export async function createBrowser(): Promise<Browser> {
+  if (useKernelBrowser) {
+    logger("Using Kernel cloud browser");
+    return createKernelBrowser();
+  }
+  return createLocalBrowser();
 }
 
 export async function createSecureBrowserContext(

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -3,7 +3,11 @@ import { getAccountTransactions } from "./scrape.js";
 import { AccountConfig, AccountScrapeResult, ScraperConfig } from "../types.js";
 import { createLogger } from "../utils/logger.js";
 import { loggerContextStore } from "../utils/asyncContext.js";
-import { createBrowser, createSecureBrowserContext } from "./browser.js";
+import {
+  createBrowser,
+  createSecureBrowserContext,
+  useKernelBrowser,
+} from "./browser.js";
 import { getFailureScreenShotPath } from "../utils/failureScreenshot.js";
 import { ScraperOptions } from "israeli-bank-scrapers";
 import { parallelLimit } from "async";
@@ -89,7 +93,11 @@ export async function scrapeAccounts(
 
   try {
     logger(`closing browser`);
-    await browser?.close();
+    if (useKernelBrowser) {
+      await browser?.disconnect();
+    } else {
+      await browser?.close();
+    }
   } catch (e) {
     onError?.(e, "browser.close");
     logger(`failed to close browser`, e);

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -11,6 +11,7 @@ import {
 import { getFailureScreenShotPath } from "../utils/failureScreenshot.js";
 import { ScraperOptions } from "israeli-bank-scrapers";
 import { parallelLimit } from "async";
+import type { Browser } from "puppeteer";
 
 const logger = createLogger("scraper");
 
@@ -53,17 +54,29 @@ export async function scrapeAccounts(
 
   const status: Array<string> = [];
 
-  logger("Creating a browser");
-  const browser = await createBrowser();
-  logger(`Browser created, starting to scrape ${accounts.length} accounts`);
+  // Kernel cloud browsers use separate instances per company to avoid
+  // same-bank fingerprint detection when scraping multiple accounts.
+  // Local mode uses a single shared browser as before.
+  const browsers = new Map<string, Browser>();
+  const getBrowser = async (companyId: string): Promise<Browser> => {
+    const key = useKernelBrowser ? companyId : "shared";
+    let browser = browsers.get(key);
+    if (!browser) {
+      logger(`Creating browser for %s`, key);
+      browser = await createBrowser();
+      browsers.set(key, browser);
+    }
+    return browser;
+  };
 
   const results = await parallelLimit<AccountConfig, AccountScrapeResult[]>(
     accounts.map((account, i) => async () => {
       const { companyId } = account;
       return loggerContextStore.run(
         { prefix: `[#${i} ${companyId}]` },
-        async () =>
-          scrapeAccount(
+        async () => {
+          const browser = await getBrowser(companyId);
+          return scrapeAccount(
             account,
             {
               browserContext: await createSecureBrowserContext(
@@ -82,7 +95,8 @@ export async function scrapeAccounts(
               status[i] = append ? `${status[i]} ${message}` : message;
               return scrapeStatusChanged?.(status);
             },
-          ),
+          );
+        },
       );
     }),
     Number(parallelScrapers),
@@ -91,16 +105,17 @@ export async function scrapeAccounts(
   logger(`scraping ended, total duration: ${duration.toFixed(1)}s`);
   await scrapeStatusChanged?.(status, duration);
 
-  try {
-    logger(`closing browser`);
-    if (useKernelBrowser) {
-      await browser?.disconnect();
-    } else {
-      await browser?.close();
+  for (const browser of browsers.values()) {
+    try {
+      if (useKernelBrowser) {
+        await browser.disconnect();
+      } else {
+        await browser.close();
+      }
+    } catch (e) {
+      onError?.(e as Error, "browser.close");
+      logger(`failed to close browser`, e);
     }
-  } catch (e) {
-    onError?.(e, "browser.close");
-    logger(`failed to close browser`, e);
   }
 
   logger(getStats(results));

--- a/src/test-scraper-access.ts
+++ b/src/test-scraper-access.ts
@@ -6,6 +6,7 @@ import { ScraperErrorTypes } from "israeli-bank-scrapers/lib/scrapers/errors.js"
 import {
   createBrowser,
   createSecureBrowserContext,
+  useKernelBrowser,
 } from "./scraper/browser.js";
 import { createLogger } from "./utils/logger.js";
 import { getExternalIp } from "./runnerMetadata.js";
@@ -42,7 +43,11 @@ describe("Sites access tests", () => {
   });
 
   after(async () => {
-    await browser.close();
+    if (useKernelBrowser) {
+      await browser.disconnect();
+    } else {
+      await browser.close();
+    }
   });
 
   describe("basic access", () => {


### PR DESCRIPTION
## Summary

Add support for [kernel.sh](https://kernel.sh) cloud browsers as an alternative to bundled Chromium, with a new lightweight Docker image (`moneyman-kernel`).

## Changes

### Core
- **`src/scraper/browser.ts`**: Auto-detects `KERNEL_API_KEY` env var. When set, uses `puppeteer.connect()` to a kernel.sh cloud browser instead of `puppeteer.launch()` with local Chromium. Kernel sessions use stealth mode and 1920×1080 viewport.
- **`src/scraper/index.ts`**: Uses `disconnect()` instead of `close()` for kernel browser sessions.
- **`@onkernel/sdk`**: Added as production dependency.

### Docker
- **`Dockerfile.kernel`** (new): Minimal `node:slim` image without Chromium or display libraries — significantly smaller than the standard image.

### CI/CD Pipelines
- **`build.yml`**: Builds both `moneyman` and `moneyman-kernel` images on release. Added `Dockerfile.kernel` to path triggers.
- **`pr-build.yml`**: Builds kernel image in PR pipeline for both internal and external PRs. PR comments updated to list both images.
- **`scrape.yml`**: New `useKernelBrowser` dispatch parameter. When enabled, pulls the `-kernel` image and passes `KERNEL_API_KEY` to the container.
- **`cleanup-pr.yml`**: Cleans up `moneyman-kernel` PR images on PR close.
- **`cleanup-images.yml`**: Runs cleanup for both `moneyman` and `moneyman-kernel` packages via matrix strategy.
- **`test-connections.yml`**: Added `Dockerfile.kernel` to path triggers.

## Usage

1. Add `KERNEL_API_KEY` to repository secrets (get from [kernel.sh](https://kernel.sh/docs/info/pricing))
2. Run the scrape workflow with `useKernelBrowser: true` — or use the `moneyman-kernel` image directly with the `KERNEL_API_KEY` env var

## Cost Estimate

Kernel.sh pricing is usage-based. At headful rate ($0.48/hr), typical daily scraping of 3-6 accounts (~5-10 min/day) costs **$1-3/month** — well within the free tier ($5/mo credits).

---

> This PR was authored by GitHub Copilot on behalf of @daniel-hauser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional kernel-based browser mode (env toggle) with per-account kernel instances; CI and PR summaries now show both main and kernel image sizes and statuses.
  * Scrape workflow gains an input to enable kernel mode and wires the kernel API key when active.

* **Chores**
  * Added kernel image variant with build/push/cleanup/report flows across CI workflows.
  * Added kernel-specific container entrypoint validation and a kernel SDK dependency.

* **Refactor**
  * Browser pooling and conditional shutdown/cleanup updated to support kernel mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->