### PR TITLE
fix: resolve duplicate uniqueId for identical and pending transactions

### DIFF
--- a/src/bot/__snapshots__/messages.test.ts.snap
+++ b/src/bot/__snapshots__/messages.test.ts.snap
@@ -37,7 +37,7 @@ exports[`messages getSummaryMessages should return a summary message 1`] = `
 From completed, 3 not originally in ILS and 1 not charged in ILS
 
 <blockquote expandable>⚠️ Duplicate uniqueId detected (1 unique keys affected)
-	2026-01-30_max_account2_0_description1_undefined</blockquote>
+	2026-01-30_max_account2_20_description1_undefined</blockquote>
 
 <blockquote expandable>Accounts updated
 	✔️ [max] account1: 1

--- a/src/bot/storage/index.ts
+++ b/src/bot/storage/index.ts
@@ -16,7 +16,11 @@ import { AzureDataExplorerStorage } from "./azure-data-explorer.js";
 import { BuxferStorage } from "./buxfer.js";
 import { LocalJsonStorage } from "./json.js";
 import { GoogleSheetsStorage } from "./sheets.js";
-import { transactionHash, transactionUniqueId } from "./utils.js";
+import {
+  transactionHash,
+  transactionUniqueId,
+  disambiguateDuplicateIds,
+} from "./utils.js";
 import { WebPostStorage } from "./web-post.js";
 import { TelegramStorage } from "./telegram.js";
 import { YNABStorage } from "./ynab.js";
@@ -136,5 +140,5 @@ function resultsToTransactions(
     }
   }
 
-  return txns;
+  return disambiguateDuplicateIds(txns);
 }

--- a/src/bot/storage/utils.test.ts
+++ b/src/bot/storage/utils.test.ts
@@ -3,8 +3,13 @@ import {
   TransactionStatuses,
   TransactionTypes,
 } from "israeli-bank-scrapers/lib/transactions.js";
-import { transactionUniqueId, transactionHash } from "./utils.js";
+import {
+  transactionUniqueId,
+  transactionHash,
+  disambiguateDuplicateIds,
+} from "./utils.js";
 import { CompanyTypes } from "israeli-bank-scrapers";
+import { transactionRow } from "../../utils/tests.js";
 
 const transaction1: Transaction = {
   date: "2021-01-01",
@@ -251,4 +256,134 @@ describe("transactionUniqueId", () => {
       expect(id).toContain(`${tx.description}_${tx.memo}`);
     },
   );
+
+  it("Issue #827: pending transactions with different originalAmounts should get different unique ids", () => {
+    const companyId = CompanyTypes.hapoalim;
+    const accountNumber = "123";
+
+    const pendingTx1: Transaction = {
+      ...transaction1,
+      chargedAmount: 0,
+      originalAmount: 50,
+      identifier: undefined,
+      status: TransactionStatuses.Pending,
+    };
+
+    const pendingTx2: Transaction = {
+      ...transaction1,
+      chargedAmount: 0,
+      originalAmount: 30,
+      identifier: undefined,
+      status: TransactionStatuses.Pending,
+    };
+
+    const id1 = transactionUniqueId(pendingTx1, companyId, accountNumber);
+    const id2 = transactionUniqueId(pendingTx2, companyId, accountNumber);
+
+    expect(id1).not.toBe(id2);
+  });
+
+  it("Issue #827: uses originalAmount when chargedAmount is 0", () => {
+    const companyId = CompanyTypes.hapoalim;
+    const accountNumber = "123";
+
+    const pendingTx: Transaction = {
+      ...transaction1,
+      chargedAmount: 0,
+      originalAmount: 75,
+      identifier: undefined,
+      status: TransactionStatuses.Pending,
+    };
+
+    const id = transactionUniqueId(pendingTx, companyId, accountNumber);
+    expect(id).toContain("75");
+    expect(id).not.toContain("_0_");
+  });
+});
+
+describe("disambiguateDuplicateIds", () => {
+  it("leaves a batch with no duplicates unchanged", () => {
+    const txns = [
+      transactionRow({ uniqueId: "a" }),
+      transactionRow({ uniqueId: "b" }),
+      transactionRow({ uniqueId: "c" }),
+    ];
+    const result = disambiguateDuplicateIds(txns);
+    expect(result.map((t) => t.uniqueId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("Issue #827: appends _1, _2 to subsequent collisions (coffee bought twice)", () => {
+    const txns = [
+      transactionRow({ uniqueId: "coffee" }),
+      transactionRow({ uniqueId: "coffee" }),
+      transactionRow({ uniqueId: "coffee" }),
+    ];
+    const result = disambiguateDuplicateIds(txns);
+    expect(result.map((t) => t.uniqueId)).toEqual([
+      "coffee",
+      "coffee_1",
+      "coffee_2",
+    ]);
+  });
+
+  it("first occurrence keeps its original uniqueId (backwards-compatible)", () => {
+    const original = transactionRow({ uniqueId: "orig" });
+    const [first] = disambiguateDuplicateIds([
+      original,
+      transactionRow({ uniqueId: "orig" }),
+    ]);
+    expect(first.uniqueId).toBe("orig");
+    expect(first).toBe(original); // same object reference, not a copy
+  });
+
+  it("handles interleaved duplicates independently", () => {
+    const txns = [
+      transactionRow({ uniqueId: "a" }),
+      transactionRow({ uniqueId: "b" }),
+      transactionRow({ uniqueId: "a" }),
+      transactionRow({ uniqueId: "b" }),
+      transactionRow({ uniqueId: "a" }),
+    ];
+    const result = disambiguateDuplicateIds(txns);
+    expect(result.map((t) => t.uniqueId)).toEqual([
+      "a",
+      "b",
+      "a_1",
+      "b_1",
+      "a_2",
+    ]);
+  });
+
+  it("does not collide when batch already contains a pre-suffixed id", () => {
+    // ["a", "a_1", "a"] — "a_1" is a natural id in the batch;
+    // the duplicate "a" must skip to "a_2" instead of reusing "a_1".
+    const txns = [
+      transactionRow({ uniqueId: "a" }),
+      transactionRow({ uniqueId: "a_1" }),
+      transactionRow({ uniqueId: "a" }),
+    ];
+    const result = disambiguateDuplicateIds(txns);
+    const ids = result.map((t) => t.uniqueId);
+    expect(ids).toEqual(["a", "a_1", "a_2"]);
+    expect(new Set(ids).size).toBe(ids.length); // all unique
+  });
+});
+
+describe("transactionUniqueId — non-pending zero-amount", () => {
+  it("preserves chargedAmount 0 for a completed transaction (does not fall back to originalAmount)", () => {
+    const companyId = CompanyTypes.hapoalim;
+    const accountNumber = "123";
+
+    const completedZeroTx: Transaction = {
+      ...transaction1,
+      chargedAmount: 0,
+      originalAmount: 75,
+      identifier: undefined,
+      status: TransactionStatuses.Completed,
+    };
+
+    const id = transactionUniqueId(completedZeroTx, companyId, accountNumber);
+    expect(id).toContain("_0_");
+    expect(id).not.toContain("75");
+  });
 });

--- a/src/bot/storage/utils.ts
+++ b/src/bot/storage/utils.ts
@@ -1,6 +1,10 @@
 import { formatISO, parseISO, roundToNearestMinutes } from "date-fns";
 import type { CompanyTypes } from "israeli-bank-scrapers";
-import type { Transaction } from "israeli-bank-scrapers/lib/transactions.js";
+import {
+  type Transaction,
+  TransactionStatuses,
+} from "israeli-bank-scrapers/lib/transactions.js";
+import type { TransactionRow } from "../../types.js";
 
 /**
  * Generates a hash for a transaction that can be used to ~uniquely identify it.
@@ -40,12 +44,54 @@ export function transactionUniqueId(
     representation: "date",
   });
 
+  // Pending transactions report chargedAmount as 0; fall back to originalAmount
+  // so two pending transactions with different original amounts get distinct ids.
+  // Non-pending transactions preserve chargedAmount even when it is 0.
+  const isPending = tx.status === TransactionStatuses.Pending;
+  const amount =
+    isPending && tx.chargedAmount === 0 ? tx.originalAmount : tx.chargedAmount;
+
   const parts = [
     date,
     companyId,
     accountNumber,
-    tx.chargedAmount,
+    amount,
     tx.identifier || `${tx.description}_${tx.memo}`,
   ];
   return parts.map((p) => String(p ?? "").trim()).join("_");
+}
+
+/**
+ * Appends a numeric suffix to uniqueIds that collide within the same batch.
+ * The first occurrence keeps its original uniqueId (backwards-compatible);
+ * subsequent occurrences get `_1`, `_2`, etc.
+ *
+ * This handles legitimately identical-looking transactions (e.g. buying the
+ * same item twice on the same day with no bank-assigned identifier) so they
+ * are stored as distinct rows instead of being merged or silently dropped.
+ */
+export function disambiguateDuplicateIds(
+  txns: Array<TransactionRow>,
+): Array<TransactionRow> {
+  const counts = new Map<string, number>();
+  // Pre-populate with all original uniqueIds so generated suffixes never
+  // collide with a natural ID that appears later in the batch.
+  const seen = new Set<string>(txns.map((tx) => tx.uniqueId));
+
+  return txns.map((tx) => {
+    const base = tx.uniqueId;
+    const count = counts.get(base) ?? 0;
+    counts.set(base, count + 1);
+
+    if (count === 0) return tx;
+
+    let n = count;
+    while (seen.has(`${base}_${n}`)) {
+      n++;
+    }
+    const uniqueId = `${base}_${n}`;
+    seen.add(uniqueId);
+    counts.set(base, n + 1);
+    return { ...tx, uniqueId };
+  });
 }


### PR DESCRIPTION
### **Problem**

Two distinct bugs both cause a:

> **⚠️  Duplicate uniqueId detected warning** 


and result in transactions being silently dropped or merged:

1. Pending transactions (e.g. Max) : pending transactions report chargedAmount: 0 regardless of the actual amount.
Two pending transactions from the same merchant on the same day, even with different amounts, would produce identical uniqueIds.

2. Legitimately identical transactions : buying the same item twice on the same day (same merchant, same amount, no bank-assigned identifier) produces identical uniqueIds.
The second transaction gets dropped in Google Sheets or overwrites the first in SQL.

Both issues only occur when identifier is not set by the bank. When identifier is present, the existing logic works correctly.

### **Fix**

For pending transactions: fall back to originalAmount when chargedAmount is 0, since originalAmount reflects the real transaction amount even while pending.

For identical-looking transactions: add disambiguateDuplicateIds at the batch level - after all transactions are assembled, any colliding uniqueIds get a _1, _2 suffix appended. 
The first occurrence keeps its original uniqueId (backwards-compatible with existing stored data).

### **Reproduction**

  // Before fix — both produce the same uniqueId:
  pending ₪50  → 2024-11-01_max_1234_0_COFFEE SHOP_
  pending ₪30  → 2024-11-01_max_1234_0_COFFEE SHOP_  ← collision

  // After fix:
  pending ₪50  → 2024-11-01_max_1234_50_COFFEE SHOP_
  pending ₪30  → 2024-11-01_max_1234_30_COFFEE SHOP_  ← distinct

### **Notes**

- The _1 suffix for identical transactions is assigned by position within the scraped batch. If the bank returns the same transactions in a different order on a re-run, the suffix could shift. 
This is an inherent limitation when the bank provides no identifier.
- Pending transactions are skipped by YNAB and Google Sheets, so the pending fix only affects SQL storage.

Fixes #827


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction ID generation for pending items with zero charged amount so distinct original amounts no longer collide.
  * Added batch-level duplicate-ID disambiguation to ensure distinct transactions are preserved and uniquely identified.

* **Tests**
  * Added tests covering duplicate-ID resolution, edge cases with pre-suffixed IDs, and charged vs. original amount behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->