### PR TITLE
feat: improve scraping reliability and same-company account handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ options: {
      */
     maxParallelScrapers?: number;
     /**
+     * Retry scrapes that fail with a generic error, after a short delay
+     * @default true
+     */
+    retryFailedScrapes?: boolean;
+    /**
      * Enable tracking of all domains accessed during scraping
      * @default false
      */

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -33,6 +33,8 @@
       // "futureMonths": 1,
       // Maximum number of parallel scrapers (default: 1)
       // "maxParallelScrapers": 1,
+      // Retry scrapes that fail with a generic error (default: true)
+      // "retryFailedScrapes": true,
       // Include raw transaction data for debugging purposes (default: false)
       // "includeRawTransaction": false
     },

--- a/patches/israeli-bank-scrapers+6.7.1.patch
+++ b/patches/israeli-bank-scrapers+6.7.1.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/israeli-bank-scrapers/lib/scrapers/visa-cal.js b/node_modules/israeli-bank-scrapers/lib/scrapers/visa-cal.js
+index 85efbdb..1babc0f 100644
+--- a/node_modules/israeli-bank-scrapers/lib/scrapers/visa-cal.js
++++ b/node_modules/israeli-bank-scrapers/lib/scrapers/visa-cal.js
+@@ -169,7 +169,7 @@ class VisaCalScraper extends _baseScraperWithBrowser.BaseScraperWithBrowser {
+     return frame;
+   };
+   async getCards() {
+-    const initData = await (0, _waiting.waitUntil)(() => (0, _storage.getFromSessionStorage)(this.page, 'init'), 'get init data in session storage', 10000, 1000);
++    const initData = await (0, _waiting.waitUntil)(() => (0, _storage.getFromSessionStorage)(this.page, 'init'), 'get init data in session storage', 20000, 1000);
+     if (!initData) {
+       throw new Error('could not find "init" data in session storage');
+     }
+@@ -184,7 +184,7 @@ class VisaCalScraper extends _baseScraperWithBrowser.BaseScraperWithBrowser {
+   async getAuthorizationHeader() {
+     if (!this.authorization) {
+       debug('fetching authorization header');
+-      const authModule = await (0, _waiting.waitUntil)(async () => authModuleOrUndefined(await (0, _storage.getFromSessionStorage)(this.page, 'auth-module')), 'get authorization header with valid token in session storage', 10_000, 50);
++      const authModule = await (0, _waiting.waitUntil)(async () => authModuleOrUndefined(await (0, _storage.getFromSessionStorage)(this.page, 'auth-module')), 'get authorization header with valid token in session storage', 15000, 50);
+       return `CALAuthScheme ${authModule.auth.calConnectToken}`;
+     }
+     return this.authorization;

--- a/src/bot/storage/sheets.test.ts
+++ b/src/bot/storage/sheets.test.ts
@@ -179,6 +179,7 @@ describe("GoogleSheetsStorage", () => {
             includeRawTransaction: false,
             hiddenDeprecations: [],
             maxParallelScrapers: 1,
+            retryFailedScrapes: true,
             domainTracking: false,
           },
           security: {

--- a/src/config.schema.ts
+++ b/src/config.schema.ts
@@ -121,6 +121,7 @@ export const ScrapingOptionsSchema = z.object({
   hiddenDeprecations: z.array(z.string()).default([]),
   puppeteerExecutablePath: z.string().optional(),
   maxParallelScrapers: z.number().min(1).max(10).default(1),
+  retryFailedScrapes: z.boolean().default(true),
   domainTracking: z.boolean().default(false),
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,6 +96,7 @@ export const scraperConfig: ScraperConfig = {
   accounts: getAccounts(),
   startDate: subDays(Date.now(), config.options.scraping.daysBack),
   parallelScrapers: config.options.scraping.maxParallelScrapers,
+  retryFailedScrapes: config.options.scraping.retryFailedScrapes,
   futureMonthsToScrape: config.options.scraping.futureMonths,
   additionalTransactionInformation:
     config.options.scraping.additionalTransactionInfo,

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -53,36 +53,76 @@ export async function scrapeAccounts(
   const browser = await createBrowser();
   logger(`Browser created, starting to scrape ${accounts.length} accounts`);
 
-  const results = await parallelLimit<AccountConfig, AccountScrapeResult[]>(
-    accounts.map((account, i) => async () => {
-      const { companyId } = account;
-      return loggerContextStore.run(
-        { prefix: `[#${i} ${companyId}]` },
-        async () =>
-          scrapeAccount(
-            account,
-            {
-              browserContext: await createSecureBrowserContext(
-                browser,
-                companyId,
-              ),
-              startDate,
+  // Group accounts by companyId so same-company accounts run sequentially
+  // (they share a browser/IP and may conflict if run in parallel)
+  const companyGroups = new Map<string, Array<{ account: AccountConfig; index: number }>>();
+  accounts.forEach((account, i) => {
+    const group = companyGroups.get(account.companyId) ?? [];
+    group.push({ account, index: i });
+    companyGroups.set(account.companyId, group);
+  });
+
+  // Show initial "Waiting" status for queued same-company accounts
+  for (const [, members] of companyGroups) {
+    for (let j = 1; j < members.length; j++) {
+      const { account, index } = members[j];
+      status[index] = `[${account.companyId}] ⏳ Waiting`;
+    }
+  }
+  if (companyGroups.size < accounts.length) {
+    await scrapeStatusChanged?.(status);
+  }
+
+  const scrapeOne = async (account: AccountConfig, i: number) => {
+    const { companyId } = account;
+    return loggerContextStore.run(
+      { prefix: `[#${i} ${companyId}]` },
+      async () =>
+        scrapeAccount(
+          account,
+          {
+            browserContext: await createSecureBrowserContext(
+              browser,
               companyId,
-              futureMonthsToScrape: futureMonths,
-              storeFailureScreenShotPath: getFailureScreenShotPath(companyId),
-              additionalTransactionInformation,
-              includeRawTransaction,
-              ...scraperOptions,
-            },
-            async (message, append = false) => {
-              status[i] = append ? `${status[i]} ${message}` : message;
-              return scrapeStatusChanged?.(status);
-            },
-          ),
-      );
-    }),
-    Number(parallelScrapers),
+            ),
+            startDate,
+            companyId,
+            futureMonthsToScrape: futureMonths,
+            storeFailureScreenShotPath: getFailureScreenShotPath(companyId),
+            additionalTransactionInformation,
+            includeRawTransaction,
+            ...scraperOptions,
+          },
+          async (message, append = false) => {
+            status[i] = append ? `${status[i]} ${message}` : message;
+            return scrapeStatusChanged?.(status);
+          },
+        ),
+    );
+  };
+
+  // Each company group is a single task that runs its accounts sequentially
+  const groupTasks = [...companyGroups.entries()].map(
+    ([, members]) => async () => {
+      const groupResults: AccountScrapeResult[] = [];
+      for (let j = 0; j < members.length; j++) {
+        const { account, index } = members[j];
+        if (j > 0) {
+          status[index] = `[${account.companyId}] ⏳ Waiting`;
+          await scrapeStatusChanged?.(status);
+        }
+        groupResults.push(await scrapeOne(account, index));
+      }
+      return groupResults;
+    },
   );
+
+  const groupResults = await parallelLimit<
+    (typeof groupTasks)[number],
+    AccountScrapeResult[][]
+  >(groupTasks, Number(parallelScrapers));
+
+  const results = groupResults.flat();
   const duration = (performance.now() - start) / 1000;
   logger(`scraping ended, total duration: ${duration.toFixed(1)}s`);
   await scrapeStatusChanged?.(status, duration);

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -6,10 +6,12 @@ import { loggerContextStore } from "../utils/asyncContext.js";
 import { createBrowser, createSecureBrowserContext } from "./browser.js";
 import { getFailureScreenShotPath } from "../utils/failureScreenshot.js";
 import { ScraperOptions } from "israeli-bank-scrapers";
+import { ScraperErrorTypes } from "israeli-bank-scrapers/lib/scrapers/errors.js";
 import { parallelLimit } from "async";
 import { setTimeout } from "timers/promises";
 
-const SAME_COMPANY_DELAY_MS = 10_000;
+const SAME_COMPANY_DELAY_MS = 1_000;
+const RETRY_DELAY_MS = 5_000;
 
 const logger = createLogger("scraper");
 
@@ -30,6 +32,7 @@ export async function scrapeAccounts(
     startDate,
     futureMonthsToScrape,
     parallelScrapers,
+    retryFailedScrapes,
     additionalTransactionInformation,
     includeRawTransaction,
   }: ScraperConfig,
@@ -76,35 +79,55 @@ export async function scrapeAccounts(
 
   const scrapeOne = async (account: AccountConfig, i: number) => {
     const { companyId } = account;
-    const browserContext = await createSecureBrowserContext(browser, companyId);
+
+    const attemptScrape = async () => {
+      const browserContext = await createSecureBrowserContext(
+        browser,
+        companyId,
+      );
+      try {
+        return await scrapeAccount(
+          account,
+          {
+            browserContext,
+            startDate,
+            companyId,
+            futureMonthsToScrape: futureMonths,
+            storeFailureScreenShotPath: getFailureScreenShotPath(companyId),
+            additionalTransactionInformation,
+            includeRawTransaction,
+            ...scraperOptions,
+          },
+          async (message, append = false) => {
+            status[i] = append ? `${status[i]} ${message}` : message;
+            return scrapeStatusChanged?.(status);
+          },
+        );
+      } finally {
+        try {
+          await browserContext.close();
+        } catch (e) {
+          logger(`failed to close browser context`, e);
+        }
+      }
+    };
+
     return loggerContextStore.run(
       { prefix: `[#${i} ${companyId}]` },
       async () => {
-        try {
-          return await scrapeAccount(
-            account,
-            {
-              browserContext,
-              startDate,
-              companyId,
-              futureMonthsToScrape: futureMonths,
-              storeFailureScreenShotPath: getFailureScreenShotPath(companyId),
-              additionalTransactionInformation,
-              includeRawTransaction,
-              ...scraperOptions,
-            },
-            async (message, append = false) => {
-              status[i] = append ? `${status[i]} ${message}` : message;
-              return scrapeStatusChanged?.(status);
-            },
-          );
-        } finally {
-          try {
-            await browserContext.close();
-          } catch (e) {
-            logger(`failed to close browser context`, e);
-          }
+        const result = await attemptScrape();
+        if (
+          retryFailedScrapes &&
+          !result.result.success &&
+          result.result.errorType === ScraperErrorTypes.Generic
+        ) {
+          logger(`scrape failed with GENERIC error, retrying in ${RETRY_DELAY_MS}ms`);
+          status[i] = `[${companyId}] 🔄 Retrying`;
+          await scrapeStatusChanged?.(status);
+          await setTimeout(RETRY_DELAY_MS);
+          return attemptScrape();
         }
+        return result;
       },
     );
   };

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -9,7 +9,7 @@ import { ScraperOptions } from "israeli-bank-scrapers";
 import { parallelLimit } from "async";
 import { setTimeout } from "timers/promises";
 
-const SAME_COMPANY_DELAY_MS = 3000;
+const SAME_COMPANY_DELAY_MS = 10_000;
 
 const logger = createLogger("scraper");
 
@@ -76,29 +76,36 @@ export async function scrapeAccounts(
 
   const scrapeOne = async (account: AccountConfig, i: number) => {
     const { companyId } = account;
+    const browserContext = await createSecureBrowserContext(browser, companyId);
     return loggerContextStore.run(
       { prefix: `[#${i} ${companyId}]` },
-      async () =>
-        scrapeAccount(
-          account,
-          {
-            browserContext: await createSecureBrowserContext(
-              browser,
+      async () => {
+        try {
+          return await scrapeAccount(
+            account,
+            {
+              browserContext,
+              startDate,
               companyId,
-            ),
-            startDate,
-            companyId,
-            futureMonthsToScrape: futureMonths,
-            storeFailureScreenShotPath: getFailureScreenShotPath(companyId),
-            additionalTransactionInformation,
-            includeRawTransaction,
-            ...scraperOptions,
-          },
-          async (message, append = false) => {
-            status[i] = append ? `${status[i]} ${message}` : message;
-            return scrapeStatusChanged?.(status);
-          },
-        ),
+              futureMonthsToScrape: futureMonths,
+              storeFailureScreenShotPath: getFailureScreenShotPath(companyId),
+              additionalTransactionInformation,
+              includeRawTransaction,
+              ...scraperOptions,
+            },
+            async (message, append = false) => {
+              status[i] = append ? `${status[i]} ${message}` : message;
+              return scrapeStatusChanged?.(status);
+            },
+          );
+        } finally {
+          try {
+            await browserContext.close();
+          } catch (e) {
+            logger(`failed to close browser context`, e);
+          }
+        }
+      },
     );
   };
 

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -121,7 +121,9 @@ export async function scrapeAccounts(
           !result.result.success &&
           result.result.errorType === ScraperErrorTypes.Generic
         ) {
-          logger(`scrape failed with GENERIC error, retrying in ${RETRY_DELAY_MS}ms`);
+          logger(
+            `scrape failed with GENERIC error, retrying in ${RETRY_DELAY_MS}ms`,
+          );
           status[i] = `[${companyId}] 🔄 Retrying`;
           await scrapeStatusChanged?.(status);
           await setTimeout(RETRY_DELAY_MS);

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -55,24 +55,17 @@ export async function scrapeAccounts(
 
   // Group accounts by companyId so same-company accounts run sequentially
   // (they share a browser/IP and may conflict if run in parallel)
-  const companyGroups = new Map<
-    string,
-    Array<{ account: AccountConfig; index: number }>
-  >();
-  accounts.forEach((account, i) => {
-    const group = companyGroups.get(account.companyId) ?? [];
-    group.push({ account, index: i });
-    companyGroups.set(account.companyId, group);
-  });
+  const indexed = accounts.map((account, index) => ({ account, index }));
+  const companyGroups = Object.groupBy(indexed, ({ account }) => account.companyId);
 
   // Show initial "Waiting" status for queued same-company accounts
-  for (const [, members] of companyGroups) {
-    for (let j = 1; j < members.length; j++) {
-      const { account, index } = members[j];
+  for (const members of Object.values(companyGroups)) {
+    for (let j = 1; j < members!.length; j++) {
+      const { account, index } = members![j];
       status[index] = `[${account.companyId}] ⏳ Waiting`;
     }
   }
-  if (companyGroups.size < accounts.length) {
+  if (Object.keys(companyGroups).length < accounts.length) {
     await scrapeStatusChanged?.(status);
   }
 
@@ -105,20 +98,19 @@ export async function scrapeAccounts(
   };
 
   // Each company group is a single task that runs its accounts sequentially
-  const groupTasks = [...companyGroups.entries()].map(
-    ([, members]) =>
-      async () => {
-        const groupResults: AccountScrapeResult[] = [];
-        for (let j = 0; j < members.length; j++) {
-          const { account, index } = members[j];
-          if (j > 0) {
-            status[index] = `[${account.companyId}] ⏳ Waiting`;
-            await scrapeStatusChanged?.(status);
-          }
-          groupResults.push(await scrapeOne(account, index));
+  const groupTasks = Object.values(companyGroups).map(
+    (members) => async () => {
+      const groupResults: AccountScrapeResult[] = [];
+      for (let j = 0; j < members!.length; j++) {
+        const { account, index } = members![j];
+        if (j > 0) {
+          status[index] = `[${account.companyId}] ⏳ Waiting`;
+          await scrapeStatusChanged?.(status);
         }
-        return groupResults;
-      },
+        groupResults.push(await scrapeOne(account, index));
+      }
+      return groupResults;
+    },
   );
 
   const groupResults = await parallelLimit<

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -55,7 +55,10 @@ export async function scrapeAccounts(
 
   // Group accounts by companyId so same-company accounts run sequentially
   // (they share a browser/IP and may conflict if run in parallel)
-  const companyGroups = new Map<string, Array<{ account: AccountConfig; index: number }>>();
+  const companyGroups = new Map<
+    string,
+    Array<{ account: AccountConfig; index: number }>
+  >();
   accounts.forEach((account, i) => {
     const group = companyGroups.get(account.companyId) ?? [];
     group.push({ account, index: i });
@@ -103,18 +106,19 @@ export async function scrapeAccounts(
 
   // Each company group is a single task that runs its accounts sequentially
   const groupTasks = [...companyGroups.entries()].map(
-    ([, members]) => async () => {
-      const groupResults: AccountScrapeResult[] = [];
-      for (let j = 0; j < members.length; j++) {
-        const { account, index } = members[j];
-        if (j > 0) {
-          status[index] = `[${account.companyId}] ⏳ Waiting`;
-          await scrapeStatusChanged?.(status);
+    ([, members]) =>
+      async () => {
+        const groupResults: AccountScrapeResult[] = [];
+        for (let j = 0; j < members.length; j++) {
+          const { account, index } = members[j];
+          if (j > 0) {
+            status[index] = `[${account.companyId}] ⏳ Waiting`;
+            await scrapeStatusChanged?.(status);
+          }
+          groupResults.push(await scrapeOne(account, index));
         }
-        groupResults.push(await scrapeOne(account, index));
-      }
-      return groupResults;
-    },
+        return groupResults;
+      },
   );
 
   const groupResults = await parallelLimit<

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -59,7 +59,10 @@ export async function scrapeAccounts(
   // Group accounts by companyId so same-company accounts run sequentially
   // (they share a browser/IP and may conflict if run in parallel)
   const indexed = accounts.map((account, index) => ({ account, index }));
-  const companyGroups = Object.groupBy(indexed, ({ account }) => account.companyId);
+  const companyGroups = Object.groupBy(
+    indexed,
+    ({ account }) => account.companyId,
+  );
 
   // Show initial "Waiting" status for queued same-company accounts
   for (const members of Object.values(companyGroups)) {
@@ -100,20 +103,18 @@ export async function scrapeAccounts(
   };
 
   // Each company group is a single task that runs its accounts sequentially
-  const groupTasks = Object.values(companyGroups).map(
-    (members) => async () => {
-      const groupResults: AccountScrapeResult[] = [];
-      const [first, ...rest] = members!;
-      groupResults.push(await scrapeOne(first.account, first.index));
-      for (const { account, index } of rest) {
-        status[index] = `[${account.companyId}] ⏳ Waiting`;
-        await scrapeStatusChanged?.(status);
-        await setTimeout(SAME_COMPANY_DELAY_MS);
-        groupResults.push(await scrapeOne(account, index));
-      }
-      return groupResults;
-    },
-  );
+  const groupTasks = Object.values(companyGroups).map((members) => async () => {
+    const groupResults: AccountScrapeResult[] = [];
+    const [first, ...rest] = members!;
+    groupResults.push(await scrapeOne(first.account, first.index));
+    for (const { account, index } of rest) {
+      status[index] = `[${account.companyId}] ⏳ Waiting`;
+      await scrapeStatusChanged?.(status);
+      await setTimeout(SAME_COMPANY_DELAY_MS);
+      groupResults.push(await scrapeOne(account, index));
+    }
+    return groupResults;
+  });
 
   const groupResults = await parallelLimit<
     (typeof groupTasks)[number],

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -7,6 +7,9 @@ import { createBrowser, createSecureBrowserContext } from "./browser.js";
 import { getFailureScreenShotPath } from "../utils/failureScreenshot.js";
 import { ScraperOptions } from "israeli-bank-scrapers";
 import { parallelLimit } from "async";
+import { setTimeout } from "timers/promises";
+
+const SAME_COMPANY_DELAY_MS = 3000;
 
 const logger = createLogger("scraper");
 
@@ -60,10 +63,9 @@ export async function scrapeAccounts(
 
   // Show initial "Waiting" status for queued same-company accounts
   for (const members of Object.values(companyGroups)) {
-    for (let j = 1; j < members!.length; j++) {
-      const { account, index } = members![j];
+    members!.slice(1).forEach(({ account, index }) => {
       status[index] = `[${account.companyId}] ⏳ Waiting`;
-    }
+    });
   }
   if (Object.keys(companyGroups).length < accounts.length) {
     await scrapeStatusChanged?.(status);
@@ -101,12 +103,12 @@ export async function scrapeAccounts(
   const groupTasks = Object.values(companyGroups).map(
     (members) => async () => {
       const groupResults: AccountScrapeResult[] = [];
-      for (let j = 0; j < members!.length; j++) {
-        const { account, index } = members![j];
-        if (j > 0) {
-          status[index] = `[${account.companyId}] ⏳ Waiting`;
-          await scrapeStatusChanged?.(status);
-        }
+      const [first, ...rest] = members!;
+      groupResults.push(await scrapeOne(first.account, first.index));
+      for (const { account, index } of rest) {
+        status[index] = `[${account.companyId}] ⏳ Waiting`;
+        await scrapeStatusChanged?.(status);
+        await setTimeout(SAME_COMPANY_DELAY_MS);
         groupResults.push(await scrapeOne(account, index));
       }
       return groupResults;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export type ScraperConfig = {
   startDate: Date;
   futureMonthsToScrape: number;
   parallelScrapers: number;
+  retryFailedScrapes: boolean;
   accounts: Array<AccountConfig>;
   additionalTransactionInformation: boolean;
   includeRawTransaction: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "strictPropertyInitialization": false,
     "esModuleInterop": true,
     "moduleResolution": "Node",
-    "target": "es2022",
+    "target": "es2024",
     "rootDir": "src",
     "outDir": "dst",
     "module": "ESNext",


### PR DESCRIPTION
Improve scraping reliability with several changes to the scraper infrastructure.

### Changes

**Visa Cal timeout patch** (via patch-package)
- Increase init data timeout from 10s to 20s
- Increase auth header timeout from 10s to 15s
- Applies the fix from https://github.com/eshaham/israeli-bank-scrapers/pull/1066

**Serialize same-company account scraping**
- Accounts sharing the same \companyId\ now run sequentially within their group (using \Object.groupBy\)
- Different companies still run in parallel (up to \maxParallelScrapers\)
- Avoids conflicts when multiple accounts for the same company share a single browser/IP
- 1s cooldown between same-company accounts
- Queued accounts show \⏳ Waiting\ status

**Browser context cleanup**
- Each browser context is now closed after scraping completes (\inally\ block)
- Prevents stale sessions from interfering with subsequent scrapes

**Retry failed scrapes** (\etryFailedScrapes\, default: \	rue\)
- Scrapes that fail with a \GENERIC\ error are automatically retried once after a 5s delay
- Shows \🔄 Retrying\ status during retry
- Configurable via \options.scraping.retryFailedScrapes\ (can be disabled by setting to \alse\)

**Other**
- Bump tsconfig target to \s2024\ (for \Object.groupBy\ support)
- Documentation for new \etryFailedScrapes\ config option in README and config example