### PR TITLE
infra: migrate husky to v9 pre-commit hook

### DIFF
--- a/.github/hooks/prettier.json
+++ b/.github/hooks/prettier.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "INPUT=$(cat); TOOL=$(echo \"$INPUT\" | jq -r '.toolName'); if [ \"$TOOL\" = \"edit\" ] || [ \"$TOOL\" = \"create\" ]; then npm run lint:fix 2>/dev/null || true; fi",
+        "comment": "Auto-format files after edit/create"
+      }
+    ]
+  }
+}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx pretty-quick --staged

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "act": "go run github.com/nektos/act@latest",
     "start": "node dst/index.js",
     "start:container": "docker compose up",
+    "prepare": "husky",
     "postinstall": "patch-package",
     "build": "tsc",
     "lint": "prettier --check .",
@@ -69,11 +70,6 @@
     "pretty-quick": "^4.2.2",
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --staged"
-    }
   },
   "overrides": {
     "google-spreadsheet": {


### PR DESCRIPTION
The husky v4-style config in \package.json\ (\husky.hooks\) does not work with husky v9. This migrates to the v9 setup so that \pretty-quick --staged\ actually runs on commit.

### Changes
- Add \prepare\ script (\husky\) to \package.json\
- Create \.husky/pre-commit\ running \
px pretty-quick --staged\
- Remove the legacy \husky.hooks\ config from \package.json\

### Why
PR #844 (by Copilot) failed CI because Prettier formatting wasn't applied before commit — the pre-commit hook was silently not running. This fix ensures formatting is enforced for all contributors, including Copilot coding agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated code formatting to run on staged changes during the commit process
  * Set up additional automated code formatting hooks for file creation and modification operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->