### PR TITLE
Format non-Error failures with util.inspect

### DIFF
--- a/src/bot/notifier.ts
+++ b/src/bot/notifier.ts
@@ -1,9 +1,10 @@
-import { Telegraf, TelegramError, Context } from "telegraf";
+import { Context, Telegraf, TelegramError } from "telegraf";
 import { message } from "telegraf/filters";
-import { createLogger, logToPublicLog } from "../utils/logger.js";
-import type { ImageWithCaption } from "../types.js";
 import { config } from "../config.js";
+import type { ImageWithCaption } from "../types.js";
+import { createLogger, logToPublicLog } from "../utils/logger.js";
 import { waitForAbortSignal } from "../utils/promises.js";
+import { formatUnknownError } from "../utils/utils.js";
 import { assignDeprecationHandler } from "./deprecationManager.js";
 
 const logger = createLogger("notifier");
@@ -153,12 +154,12 @@ function canIgnoreTelegramError(e: unknown) {
   );
 }
 
-export function sendError(message: any, caller: string = "") {
+export function sendError(message: unknown, caller: string = "") {
   return send(
     `${caller}\n❌ ${String(
       message instanceof Error
         ? `${message.message}\n${message.stack}`
-        : message,
+        : formatUnknownError(message),
     )}`.trim(),
   );
 }

--- a/src/bot/storage/actual.ts
+++ b/src/bot/storage/actual.ts
@@ -9,6 +9,7 @@ import * as path from "path";
 import type { MoneymanConfig } from "../../config.js";
 import { TransactionRow, TransactionStorage } from "../../types.js";
 import { createLogger } from "../../utils/logger.js";
+import { formatUnknownError } from "../../utils/utils.js";
 import { createSaveStats, SaveStats } from "../saveStats.js";
 
 const logger = createLogger("ActualBudgetStorage");
@@ -188,7 +189,7 @@ export class ActualBudgetStorage implements TransactionStorage {
       }
     } catch (error) {
       throw new Error(
-        `Failed to initialize Actual Budget: ${error instanceof Error ? error.message : error}`,
+        `Failed to initialize Actual Budget: ${formatUnknownError(error)}`,
       );
     }
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,27 @@
+import { inspect } from "node:util";
+
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function inspectUnknownObject(value: object): string {
+  return inspect(value, {
+    depth: 8,
+    maxArrayLength: 100,
+    breakLength: 100,
+    colors: false,
+  });
+}
+
+export function formatUnknownError(value: unknown): string {
+  if (value instanceof Error) {
+    return value.message;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value && typeof value === "object") {
+    return inspectUnknownObject(value);
+  }
+  return String(value);
 }


### PR DESCRIPTION
## Summary

- Add `formatUnknownError` in `utils.ts`: real `Error` values still use **message only** when formatted through this helper (e.g. Actual init wrap); plain objects use **`util.inspect`** so nested data and circular references do not collapse to `[object Object]`.
- **`sendError`** is unchanged for real errors: still **`message` + newline + `stack`**. Non-`Error` rejection reasons go through `formatUnknownError` so Telegram gets readable text.
- **`ActualBudgetStorage.init`** uses the same helper when wrapping failures so the Actual API can surface structured details (e.g. migration mismatch payloads) instead of `[object Object]`.

**Review:** The tooling drafted this patch in Cursor, but **I read and approved every change myself**—nothing was taken on trust without a full pass.

## Details

<details>
<summary>Original problem (verbatim logs from the failing run)</summary>

Line numbers in the excerpt were editor artifacts, not part of the logs.

```text
[Breadcrumb] {
  message: 'Loading budget /tmp/moneyman-actual-data/My-Finances-1-44b7ad0'
}

Database is out of sync with migrations: {
  appliedIds: [
    1548957970627, 1550601598648, 1555786194328,
    1561751833510, 1567699552727, 1582384163573,
    1597756566448, 1608652596043, 1608652596044,
    1612625548236, 1614782639336, 1615745967948,
    1616167010796, 1618975177358, 1632571489012,
    1679728867040, 1681115033845, 1682974838138,
    1685007876842, 1686139660866, 1688749527273,
    1688841238000, 1691233396000, 1694438752000,
    1697046240000, 1704572023730, 1704572023731,
    1707267033000, 1712784523000, 1716359441000,
    1720310586000, 1720664867241, 1720665000000,
    1722717601000, 1722804019000, 1723665565000,
    1730744182000, 1736640000000, 1737158400000,
    1738491452000, 1739139550000, 1740506588539,
    1745425408000, 1749799110000, 1749799110001,
    1754611200000, 1759260219000, 1759842823172,
    1762178745667, 1765518577215, 1768872504000
  ],
  available: [
    '1548957970627_remove-db-version.sql',
    '1550601598648_payees.sql',
    '1555786194328_remove_category_group_unique.sql',
    '1561751833510_indexes.sql',
    '1567699552727_budget.sql',
    '1582384163573_cleared.sql',
    '1597756566448_rules.sql',
    '1608652596043_parent_field.sql',
    '1608652596044_trans_views.sql',
    '1612625548236_optimize.sql',
    '1614782639336_trans_views2.sql',
    '1615745967948_meta.sql',
    '1616167010796_accounts_order.sql',
    '1618975177358_schedules.sql',
    '1632571489012_remove_cache.js',
    '1679728867040_rules_conditions.sql',
    '1681115033845_add_schedule_name.sql',
    '1682974838138_remove_payee_rules.sql',
    '1685007876842_add_category_hidden.sql',
    '1686139660866_remove_account_type.sql',
    '1688749527273_transaction_filters.sql',
    '1688841238000_add_account_type.sql',
    '1691233396000_add_schedule_next_date_tombstone.sql',
    '1694438752000_add_goal_targets.sql',
    '1697046240000_add_reconciled.sql',
    '1704572023730_add_account_sync_source.sql',
    '1704572023731_add_missing_goCardless_sync_source.sql',
    '1707267033000_reports.sql',
    '1712784523000_unhide_input_group.sql',
    '1716359441000_include_current.sql',
    '1720310586000_link_transfer_schedules.sql',
    '1720664867241_add_payee_favorite.sql',
    '1720665000000_goal_context.sql',
    '1722717601000_reports_move_selected_categories.js',
    '1722804019000_create_dashboard_table.js',
    '1723665565000_prefs.js',
    '1730744182000_fix_dashboard_table.sql',
    '1736640000000_custom_report_sorting.sql',
    '1737158400000_add_learn_categories_to_payees.sql',
    '1738491452000_sorting_rename.sql',
    '1739139550000_bank_sync_page.sql',
    '1740506588539_add_last_reconciled_at.sql',
    '1745425408000_update_budgetType_pref.sql',
    '1749799110000_add_tags.sql',
    '1749799110001_tags_tombstone.sql',
    '1754611200000_add_category_template_settings.sql',
    '1759260219000_add_trim_interval_report_setting.sql',
    '1759842823172_add_isGlobal_to_preferences.sql',
    '1762178745667_rename_csv_skip_lines_pref.sql',
    '1765518577215_multiple_dashboards.js'
  ]
}

Error updating Error: out-of-sync-migrations
    at checkDatabaseValidity (/app/node_modules/@actual-app/api/dist/app/bundle.api.js:124664:19)
    at migrate (/app/node_modules/@actual-app/api/dist/app/bundle.api.js:124672:5)
    at async runMigrations (/app/node_modules/@actual-app/api/dist/app/bundle.api.js:124680:5)
    at async updateVersion (/app/node_modules/@actual-app/api/dist/app/bundle.api.js:124697:5)
    at async _loadBudget (/app/node_modules/@actual-app/api/dist/app/bundle.api.js:125213:9)
    at async Object.loadBudget [as load-budget] (/app/node_modules/@actual-app/api/dist/app/bundle.api.js:125013:17)
    at async handlers.api/download-budget (/app/node_modules/@actual-app/api/dist/app/bundle.api.js:111504:9)

[Breadcrumb] { message: 'Closing budget' }

[ActualBudgetStorage] 2026-04-20T17:24:49.529Z moneyman:storage:ActualBudgetStorage error saving transactions Error: Failed to initialize Actual Budget: [object Object]
    at ActualBudgetStorage.init (file:///app/dst/bot/storage/actual.js:120:19)
    at async Promise.all (index 1)
    at async ActualBudgetStorage.saveTransactions (file:///app/dst/bot/storage/actual.js:22:9)
    at async file:///app/dst/bot/storage/index.js:63:31

[ActualBudgetStorage] 2026-04-20T17:24:49.530Z moneyman:notifier saveTransactions::ActualBudgetStorage

❌ Failed to initialize Actual Budget: [object Object]

Error: Failed to initialize Actual Budget: [object Object]
    at ActualBudgetStorage.init (file:///app/dst/bot/storage/actual.js:120:19)
    at async Promise.all (index 1)
    at async ActualBudgetStorage.saveTransactions (file:///app/dst/bot/storage/actual.js:22:9)
    at async file:///app/dst/bot/storage/index.js:63:31

uncaughtException, sending error

[ActualBudgetStorage] 2026-04-20T17:24:49.534Z moneyman:notifier ❌ 
    Caught exception: UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "#<Object>".

    err.stack: UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "#<Object>".

    at throwUnhandledRejectionsMode (node:internal/process/promises:330:7)
    at processPromiseRejections (node:internal/process/promises:413:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:32)

    Exception origin: unhandledRejection

[TelegramStorage] 2026-04-20T17:24:49.536Z moneyman:storage:TelegramStorage saved

2026-04-20T17:24:49.900Z moneyman:domain-security No domains recorded

2026-04-20T17:24:49.900Z moneyman:runner-metadata Used domains: {}

2026-04-20T17:24:49.902Z moneyman:bot Error: EINVAL: invalid argument, write
    at writeSync (node:fs:912:3)
    at logToPublicLog (file:///app/dst/utils/logger.js:35:17)
    at file:///app/dst/bot/index.js:37:9
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async runWithStorage (file:///app/dst/bot/index.js:16:5)
    at async run (file:///app/dst/index.js:54:9)
    at async file:///app/dst/index.js:23:1

2026-04-20T17:24:49.903Z moneyman:bot Error: ENXIO: no such device or address, open '/dev/tty'
    at writeFileSync (node:fs:2398:20)
    at logToPublicLog (file:///app/dst/utils/logger.js:44:17)
    at file:///app/dst/bot/index.js:37:9
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async runWithStorage (file:///app/dst/bot/index.js:16:5)
    at async run (file:///app/dst/index.js:54:9)
    at async file:///app/dst/index.js:23:1

Scraping ended

Sending log file

2026-04-20T17:24:49.906Z moneyman:secure-log Error: EINVAL: invalid argument, write
    at writeSync (node:fs:912:3)
    at logToPublicLog (file:///app/dst/utils/logger.js:35:17)
    at sendAndDeleteLogFile (file:///app/dst/utils/secure-log.js:37:13)
    at file:///app/dst/index.js:24:7
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)

2026-04-20T17:24:49.906Z moneyman:secure-log Error: ENXIO: no such device or address, open '/dev/tty'
    at writeFileSync (node:fs:2398:20)
    at logToPublicLog (file:///app/dst/utils/logger.js:44:17)
    at sendAndDeleteLogFile (file:///app/dst/utils/secure-log.js:37:13)
    at file:///app/dst/index.js:24:7
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)

2026-04-20T17:24:49.907Z moneyman:notifier Sending file { filePath: '/tmp/moneyman.log', caption: undefined }

2026-04-20T17:24:50.010Z moneyman:secure-log sendAndDeleteLogFile Failed: TelegramError: 400: Bad Request: file must be non-empty
    at Telegram.callApi (/app/node_modules/telegraf/lib/core/network/client.js:315:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async sendTextFile (file:///app/dst/bot/notifier.js:80:12)
    at async sendAndDeleteLogFile (file:///app/dst/utils/secure-log.js:38:13)
    at async file:///app/dst/index.js:24:1 {
  response: {
    ok: false,
    error_code: 400,
    description: 'Bad Request: file must be non-empty'
  },
  on: {
    method: 'sendDocument',
    payload: { chat_id: '50573760', document: [Object] }
  }
}

2026-04-20T17:24:50.011Z moneyman:logToPublicLog Error: EINVAL: invalid argument, write
    at writeSync (node:fs:912:3)
    at logToPublicLog (file:///app/dst/utils/logger.js:35:17)
    at sendAndDeleteLogFile (file:///app/dst/utils/secure-log.js:60:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async file:///app/dst/index.js:24:1

2026-04-20T17:24:50.011Z moneyman:logToPublicLog Error: ENXIO: no such device or address, open '/dev/tty'
    at writeFileSync (node:fs:2398:20)
    at logToPublicLog (file:///app/dst/utils/logger.js:44:17)
    at sendAndDeleteLogFile (file:///app/dst/utils/secure-log.js:60:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async file:///app/dst/index.js:24:1

sendAndDeleteLogFile Failed
```

Context from the same report (not in the log stream above):

Telegram only gets what moneyman’s notifier sends; the **`Database is out of sync with migrations`** block is printed to **stdout/stderr** (or internal logging), not folded into the short `❌ Failed to initialize…` Telegram text, so that detail never appears in the chat unless you forward a full log file (and here the log file upload failed with **file must be non-empty**).

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message formatting and consistency across error reporting throughout the application.
  * Enhanced handling of various error types to provide clearer and more readable error messages when application failures occur.
  * Better error formatting in initialization and notification systems for improved diagnostics and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->