### PR TITLE
feat(ynab): identifier-based transfer routing for ambiguous bank descriptions

### DIFF
--- a/src/bot/storage/ynab.test.ts
+++ b/src/bot/storage/ynab.test.ts
@@ -1,0 +1,225 @@
+import { transactionRow, config } from "../../utils/tests.js";
+import type { MoneymanConfig } from "../../config.js";
+import { TransactionStatuses } from "israeli-bank-scrapers/lib/transactions.js";
+
+const mockLog = jest.fn();
+jest.mock("../../utils/logger.js", () => ({
+  createLogger: () => mockLog,
+}));
+
+const mockGetPlanById = jest.fn();
+const mockGetAccounts = jest.fn();
+const mockCreateTransactions = jest.fn();
+
+jest.mock("ynab", () => ({
+  API: jest.fn().mockImplementation(() => ({
+    plans: { getPlanById: mockGetPlanById },
+    accounts: { getAccounts: mockGetAccounts },
+    transactions: { createTransactions: mockCreateTransactions },
+  })),
+  TransactionClearedStatus: { Cleared: "cleared" },
+}));
+
+// Import after the mocks are registered so the module under test picks up the
+// mocked SDK.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { YNABStorage } = require("./ynab.js");
+
+const mkConfig = (accounts: Record<string, string>): MoneymanConfig => {
+  const cfg = config();
+  cfg.storage = {
+    ynab: {
+      token: "test-token",
+      budgetId: "test-budget-id",
+      accounts,
+    },
+  };
+  return cfg;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetPlanById.mockResolvedValue({
+    data: { plan: { name: "Test Budget" } },
+  });
+  mockGetAccounts.mockResolvedValue({
+    data: {
+      accounts: [
+        {
+          id: "ynab-hapoalim-uuid",
+          name: "Hapoalim",
+          closed: false,
+          deleted: false,
+          transfer_payee_id: "hapoalim-transfer-payee",
+        },
+        {
+          id: "ynab-cal8339-uuid",
+          name: "Cal8339",
+          closed: false,
+          deleted: false,
+          transfer_payee_id: "cal8339-transfer-payee",
+        },
+        {
+          id: "ynab-cal7299-uuid",
+          name: "Cal7299",
+          closed: false,
+          deleted: false,
+          transfer_payee_id: "cal7299-transfer-payee",
+        },
+      ],
+    },
+  });
+  mockCreateTransactions.mockResolvedValue({
+    data: { transactions: [{}], duplicate_import_ids: [] },
+  });
+});
+
+describe("YNABStorage transfer routing by identifier", () => {
+  const fullConfig = () =>
+    mkConfig({
+      "hapoalim-acct": "ynab-hapoalim-uuid",
+      "8339": "ynab-cal8339-uuid",
+      "7299": "ynab-cal7299-uuid",
+    });
+
+  it("routes a transaction as a YNAB transfer when tx.identifier matches another configured account", async () => {
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "hapoalim-acct",
+      identifier: "8339",
+      description: "כאל",
+      chargedAmount: -19198.74,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    expect(mockCreateTransactions).toHaveBeenCalledTimes(1);
+    const sentTxs = mockCreateTransactions.mock.calls[0][1].transactions;
+    expect(sentTxs).toHaveLength(1);
+    expect(sentTxs[0]).toMatchObject({
+      account_id: "ynab-hapoalim-uuid",
+      payee_id: "cal8339-transfer-payee",
+    });
+    // When sending as a transfer we set payee_id only — payee_name must be
+    // absent so YNAB derives the display name from the transfer target.
+    expect(sentTxs[0].payee_name).toBeUndefined();
+  });
+
+  it("sends a normal transaction (no transfer) when tx.identifier is missing", async () => {
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "8339",
+      identifier: undefined,
+      description: "BIT",
+      chargedAmount: -50,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    const sentTx = mockCreateTransactions.mock.calls[0][1].transactions[0];
+    expect(sentTx.payee_id).toBeUndefined();
+    expect(sentTx.payee_name).toBe("BIT");
+  });
+
+  it("sends a normal transaction when tx.identifier matches no configured account", async () => {
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "hapoalim-acct",
+      identifier: "9999", // not in the accounts map
+      description: "Some Merchant",
+      chargedAmount: -100,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    const sentTx = mockCreateTransactions.mock.calls[0][1].transactions[0];
+    expect(sentTx.payee_id).toBeUndefined();
+    expect(sentTx.payee_name).toBe("Some Merchant");
+  });
+
+  it("does not self-transfer when tx.identifier resolves to the same account as tx.account", async () => {
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "8339",
+      identifier: "8339", // same as source
+      description: "Some Merchant",
+      chargedAmount: -75,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    const sentTx = mockCreateTransactions.mock.calls[0][1].transactions[0];
+    expect(sentTx.payee_id).toBeUndefined();
+    expect(sentTx.payee_name).toBe("Some Merchant");
+  });
+
+  it("logs a debug line when a transaction is routed as a transfer", async () => {
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "hapoalim-acct",
+      identifier: "8339",
+      description: "כאל",
+      chargedAmount: -19198.74,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    const transferLogCall = mockLog.mock.calls.find(
+      (args) =>
+        typeof args[0] === "string" &&
+        args[0].includes("routing tx as transfer"),
+    );
+    expect(transferLogCall).toBeDefined();
+    expect(transferLogCall[0]).toContain("8339");
+  });
+
+  it("falls back to a normal transaction when the target account has no transfer_payee_id (e.g. closed account)", async () => {
+    // Replace the Cal8339 account with one that has no transfer_payee_id.
+    mockGetAccounts.mockResolvedValueOnce({
+      data: {
+        accounts: [
+          {
+            id: "ynab-hapoalim-uuid",
+            name: "Hapoalim",
+            closed: false,
+            deleted: false,
+            transfer_payee_id: "hapoalim-transfer-payee",
+          },
+          {
+            id: "ynab-cal8339-uuid",
+            name: "Cal8339 (closed)",
+            closed: true,
+            deleted: false,
+            transfer_payee_id: null,
+          },
+        ],
+      },
+    });
+
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "hapoalim-acct",
+      identifier: "8339",
+      description: "כאל",
+      chargedAmount: -19198.74,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    const sentTx = mockCreateTransactions.mock.calls[0][1].transactions[0];
+    expect(sentTx.payee_id).toBeUndefined();
+    expect(sentTx.payee_name).toBe("כאל");
+  });
+});

--- a/src/bot/storage/ynab.ts
+++ b/src/bot/storage/ynab.ts
@@ -16,6 +16,7 @@ export class YNABStorage implements TransactionStorage {
   private ynabAPI: ynab.API;
   private budgetName = "";
   private accountToYnabAccount = new Map<string, string>();
+  private ynabAccountToTransferPayeeId = new Map<string, string>();
 
   constructor(private config: MoneymanConfig) {}
 
@@ -27,6 +28,12 @@ export class YNABStorage implements TransactionStorage {
     this.ynabAPI = new ynab.API(ynabConfig.token);
     this.budgetName = await this.getBudgetName(ynabConfig.budgetId);
     this.accountToYnabAccount = new Map(Object.entries(ynabConfig.accounts));
+    this.ynabAccountToTransferPayeeId = await this.fetchTransferPayeeIds(
+      ynabConfig.budgetId,
+    );
+    logger(
+      `loaded ${this.ynabAccountToTransferPayeeId.size} transfer payee mappings`,
+    );
   }
 
   canSave() {
@@ -115,18 +122,63 @@ export class YNABStorage implements TransactionStorage {
     }
   }
 
+  private async fetchTransferPayeeIds(
+    budgetId: string,
+  ): Promise<Map<string, string>> {
+    const accountsResponse = await this.ynabAPI.accounts.getAccounts(budgetId);
+    if (!accountsResponse.data) {
+      throw new Error(`Failed to fetch accounts for budget: ${budgetId}`);
+    }
+    const map = new Map<string, string>();
+    for (const account of accountsResponse.data.accounts) {
+      if (!account.deleted && !account.closed && account.transfer_payee_id) {
+        map.set(account.id, account.transfer_payee_id);
+      }
+    }
+    return map;
+  }
+
+  // When a scraped transaction's identifier matches the key of a *different*
+  // configured account, treat the transaction as a transfer to that account.
+  // This covers cases where the bank's activityDescription doesn't distinguish
+  // between cards (e.g. Bank Hapoalim returns the bare "כאל" for every Visa-Cal
+  // debit, with the actual card last-4 surfaced only in the reference number
+  // field — which israeli-bank-scrapers exposes as tx.identifier).
+  private resolveTransferPayeeId(
+    tx: TransactionRow,
+    sourceAccountId: string,
+  ): string | undefined {
+    const identifier = tx.identifier?.toString();
+    if (!identifier) return undefined;
+
+    const targetAccountId = this.accountToYnabAccount.get(identifier);
+    if (!targetAccountId || targetAccountId === sourceAccountId) {
+      return undefined;
+    }
+
+    const transferPayeeId =
+      this.ynabAccountToTransferPayeeId.get(targetAccountId);
+    if (transferPayeeId) {
+      logger(
+        `routing tx as transfer: source=${sourceAccountId} identifier=${identifier} -> target=${targetAccountId}`,
+      );
+    }
+    return transferPayeeId;
+  }
+
   private convertTransactionToYnabFormat(
     tx: TransactionRow,
     accountId: string,
   ): ynab.SaveTransactionWithIdOrImportId {
     const amount = Math.round(tx.chargedAmount * 1000);
+    const transferPayeeId = this.resolveTransferPayeeId(tx, accountId);
 
     return {
       account_id: accountId,
       date: format(parseISO(tx.date), YNAB_DATE_FORMAT, {}),
       amount,
-      payee_id: undefined,
-      payee_name: tx.description,
+      payee_id: transferPayeeId,
+      payee_name: transferPayeeId ? undefined : tx.description,
       cleared:
         tx.status === TransactionStatuses.Completed
           ? ynab.TransactionClearedStatus.Cleared


### PR DESCRIPTION
## Problem

The YNAB storage exporter uses `tx.description` as the YNAB `payee_name` and never reads `tx.identifier`. When a bank sends multiple distinct transactions with **identical descriptions** but distinguishing identifiers in the reference-number field, all of them land in YNAB with the same payee_name. Any YNAB payee-renaming rule then collapses them to the same Transfer payee — silently routing transactions to the wrong account.

Concrete case I hit on a real setup: two Cal credit cards (`7299` and `8339`) under one Hapoalim billing account.

- Bank Hapoalim returns `activityDescription = "כאל"` for **every** Visa-Cal monthly debit. The actual card last-4 lives in the reference-number field — which `israeli-bank-scrapers` already exposes on the transaction as `tx.identifier`.
- moneyman sends both monthly debits with `payee_name = "כאל"`.
- The user (reasonably) creates a YNAB rename rule `Is "כאל" → Transfer : Cal7299` after manually fixing one transaction.
- From then on, **every** monthly Cal debit auto-routes to the same card, regardless of which physical card actually charged. One card "swallows" the other's payments and the two accounts drift apart over time. In my case, ~₪300k of misrouted history accumulated over 18 months before I noticed.

## Fix

Use the per-transaction identifier as a routing hint.

- **`init()`**: fetch the YNAB account list once and build a `ynabAccountId → transfer_payee_id` map. Defensive `if (!response.data)` guard mirrors the existing `getBudgetName` pattern.
- **`convertTransactionToYnabFormat()`**: before serializing, if `tx.identifier` matches a *different* key in the existing `ynab.accounts` config map, send the transaction as a proper YNAB transfer (`payee_id = target.transfer_payee_id`, no `payee_name`). YNAB then auto-creates the paired transfer entry on the target account.
- Mapping is config-driven via the existing `ynab.accounts` object — **no new configuration required**.

Defensive fallbacks preserve existing behavior when:
- `tx.identifier` is missing
- it doesn't match any configured account
- it resolves to the same account (no self-transfer)
- the target account has no `transfer_payee_id` (closed account)

## Logging

Two DEBUG-level lines under `moneyman:YNABStorage`:
- `loaded N transfer payee mappings` on init
- `routing tx as transfer: source=<uuid> identifier=<X> -> target=<uuid>` per routed transaction

Useful for diagnosing multi-card setups without sprinkling `console.log`.

## Tests

`src/bot/storage/ynab.test.ts` is new (the YNAB exporter previously had no test coverage). Six cases cover all branches:
- Routes as transfer when identifier matches another configured account
- Falls back to normal txn when identifier is missing
- Falls back when identifier matches no configured account
- No self-transfer when identifier resolves to the same account
- Log line emitted on routing
- Fallback when target account has no `transfer_payee_id` (closed)

## Migration impact

Purely **additive**. Existing transactions are unaffected; new scrapes that don't match any *other* configured account's key continue to go through unchanged.

Users who have previously misrouted transactions (because of YNAB rename rules like the one above) will see correctly-routed entries for any *new* scrapes; existing wrong entries remain in YNAB and can be cleaned up manually. The misrouted YNAB rename rule can be deleted after this lands.

## Verified end-to-end

Tested on a fork against a real budget. With `DEBUG=moneyman:*`:

```
moneyman:YNABStorage loaded 3 transfer payee mappings
moneyman:YNABStorage routing tx as transfer: source=<hapoalim-uuid> identifier=8339 -> target=<cal8339-uuid>
moneyman:YNABStorage routing tx as transfer: source=<hapoalim-uuid> identifier=7299 -> target=<cal7299-uuid>
```

Both monthly debits landed as the correct `Transfer : Cal8339` and `Transfer : Cal7299` in YNAB.

## Review notes

This PR was reviewed inline by `gemini-code-assist` on the staging PR in my fork; their suggestion (defensive guard on the accounts response) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced transfer routing logic to automatically identify and properly route transactions between configured accounts during YNAB synchronization.
  * Better handling of edge cases, including self-transfer prevention and graceful fallback for accounts that don't support transfers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daniel-hauser/moneyman/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->