### PR TITLE
feat(actual): inject @actual-app/api version at container start

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,39 @@
 #!/bin/sh
 set -e
 
+# Optionally install a specific @actual-app/api version at container start so a
+# deployment can match its self-hosted Actual sync-server without rebuilding the
+# image. The Actual API talks to the server over a versioned protocol (not plain
+# HTTP), so a mismatch between this client and the server errors out.
+#
+#   MONEYMAN_ACTUAL_API_VERSION unset/empty -> use the version baked into the image
+#   MONEYMAN_ACTUAL_API_VERSION=26.5.2      -> install that exact version
+#   MONEYMAN_ACTUAL_API_VERSION=latest      -> install the newest published version
+actual_version="${MONEYMAN_ACTUAL_API_VERSION:-}"
+
+if [ -n "$actual_version" ]; then
+  installed=""
+  if [ "$actual_version" != "latest" ]; then
+    # Read the on-disk version by file path (not as a package specifier) so an
+    # "exports" map in the package cannot block the lookup.
+    installed="$(node -p "require('./node_modules/@actual-app/api/package.json').version" 2>/dev/null || true)"
+  fi
+
+  if [ "$actual_version" = "$installed" ]; then
+    echo "entrypoint: @actual-app/api@${actual_version} already installed; skipping install" >&2
+  else
+    echo "entrypoint: installing @actual-app/api@${actual_version}" >&2
+    # Install scripts stay enabled so native deps (e.g. better-sqlite3) can fetch
+    # their prebuilt binaries. Adding a single package does not trigger this
+    # project's own prepare/postinstall, so the dev-only husky/patch-package
+    # (pruned from the production image) are never invoked here.
+    if ! npm install --no-save --no-audit --no-fund "@actual-app/api@${actual_version}"; then
+      echo "entrypoint: failed to install @actual-app/api@${actual_version}" >&2
+      exit 1
+    fi
+  fi
+fi
+
 # Default command
 if [ "$#" -eq 0 ]; then
   set -- node dst/index.js

--- a/docs/actual-budget.md
+++ b/docs/actual-budget.md
@@ -41,8 +41,32 @@ Example:
 
 **Note:** Pending transactions will be skipped during import.
 
+## Pinning the `@actual-app/api` version (Docker)
+
+The Actual API talks to the sync-server over a versioned protocol rather than a
+stable HTTP contract, so the client (`@actual-app/api` bundled in moneyman) and
+your self-hosted server must be on compatible versions. When they drift you get
+errors such as `out-of-sync-migrations` (see Troubleshooting below).
+
+To match moneyman's client to your server **without rebuilding the image**, set
+`MONEYMAN_ACTUAL_API_VERSION` when running the container. On start, the
+entrypoint installs that version of `@actual-app/api` before launching:
+
+```bash
+# pin an exact version to match your server
+docker run -e MONEYMAN_ACTUAL_API_VERSION=26.5.2 ... ghcr.io/.../moneyman
+
+# or always take the newest published version
+docker run -e MONEYMAN_ACTUAL_API_VERSION=latest ... ghcr.io/.../moneyman
+```
+
+- Leave it unset (or empty) to use the version baked into the image.
+- If the requested version is already installed, the install step is skipped.
+- The install runs against the public npm registry, so the container needs
+  network access at startup.
+
 ## Troubleshooting
 
-- **`out-of-sync-migrations` error** — The budget database and the `@actual-app/api` version are out of sync. Ensure your Actual Budget server and moneyman's `@actual-app/api` dependency use compatible versions. Update both to their latest releases, or pin them to matching versions. See [actualbudget/actual#3656](https://github.com/actualbudget/actual/issues/3656) for context.
+- **`out-of-sync-migrations` error** — The budget database and the `@actual-app/api` version are out of sync. Ensure your Actual Budget server and moneyman's `@actual-app/api` dependency use compatible versions. Update both to their latest releases, or pin them to matching versions (see "Pinning the `@actual-app/api` version" above). See [actualbudget/actual#3656](https://github.com/actualbudget/actual/issues/3656) for context.
 
   You may see a generic error in the logs (e.g. `Failed to initialize Actual Budget: No budget file is open`). The underlying cause appears earlier in the console as `Error updating Error: out-of-sync-migrations` — look for that when diagnosing.


### PR DESCRIPTION
Sometimes moneyman's bundled `@actual-app/api` doesn't match your self-hosted
Actual server and you get `out-of-sync-migrations`, which meant rebuilding the
image to fix.

Set `MONEYMAN_ACTUAL_API_VERSION` and the entrypoint installs that version on
start. No rebuild needed.

- `26.5.2` → that exact version
- `latest` → newest one
- unset → whatever's in the image (same as today)

Docs updated too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a specific Actual API client version at container startup using `MONEYMAN_ACTUAL_API_VERSION`.
  * Automatically skips installation when the requested version is already available.

* **Bug Fixes**
  * Improved compatibility troubleshooting for mismatched Actual Budget server and client versions.

* **Documentation**
  * Added Docker setup guidance for configuring API version compatibility, including startup network requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->